### PR TITLE
feat: save identity data to sf's config and to the server

### DIFF
--- a/messages/lightning.preview.app.md
+++ b/messages/lightning.preview.app.md
@@ -39,6 +39,14 @@ For mobile virtual devices, specify the device ID to preview. If omitted, the fi
 
 Org must have a valid user
 
+# error.identitydata
+
+Couldn't find identity data while generating preview arguments
+
+# error.identitydata.entityid
+
+Couldn't find entity ID while generating preview arguments
+
 # error.no-project
 
 This command is required to run from within a Salesforce project directory. %s

--- a/messages/lightning.preview.app.md
+++ b/messages/lightning.preview.app.md
@@ -35,6 +35,10 @@ Type of device to emulate in preview.
 
 For mobile virtual devices, specify the device ID to preview. If omitted, the first available virtual device will be used.
 
+# error.username
+
+Org must have a valid user
+
 # error.no-project
 
 This command is required to run from within a Salesforce project directory. %s

--- a/messages/shared.utils.md
+++ b/messages/shared.utils.md
@@ -16,7 +16,7 @@ Valid workspace value is "SalesforceCLI" OR "mrt"
 
 # config-utils.token-desc
 
-The Base64-encoded identity token of the local web server
+The identity data is a data structure that ties together a single local web server identity token to multiple orgs.
 
 # config-utils.cert-desc
 

--- a/messages/shared.utils.md
+++ b/messages/shared.utils.md
@@ -14,7 +14,7 @@ The workspace name of the local lwc dev server
 
 Valid workspace value is "SalesforceCLI" OR "mrt"
 
-# config-utils.token-desc
+# config-utils.data-desc
 
 The identity data is a data structure that links the local web server's identity token to the user's configured Salesforce orgs.
 

--- a/messages/shared.utils.md
+++ b/messages/shared.utils.md
@@ -16,7 +16,7 @@ Valid workspace value is "SalesforceCLI" OR "mrt"
 
 # config-utils.token-desc
 
-The identity data is a data structure that ties together a single local web server identity token to multiple orgs.
+The identity data is a data structure that links the local web server's identity token to the user's configured Salesforce orgs.
 
 # config-utils.cert-desc
 

--- a/src/commands/lightning/preview/app.ts
+++ b/src/commands/lightning/preview/app.ts
@@ -206,15 +206,17 @@ export default class LightningPreviewApp extends SfCommand<void> {
     const ldpServerUrl = PreviewUtils.generateWebSocketUrlForLocalDevServer(platform, serverPort, logger);
     logger.debug(`Local Dev Server url is ${ldpServerUrl}`);
 
+    const entityId = await PreviewUtils.getEntityId(username);
+
     if (platform === Platform.desktop) {
-      await this.desktopPreview(sfdxProjectRootPath, serverPort, token, username, ldpServerUrl, appId, logger);
+      await this.desktopPreview(sfdxProjectRootPath, serverPort, token, entityId, ldpServerUrl, appId, logger);
     } else {
       await this.mobilePreview(
         platform,
         sfdxProjectRootPath,
         serverPort,
         token,
-        username,
+        entityId,
         ldpServerUrl,
         appName,
         appId,
@@ -228,7 +230,7 @@ export default class LightningPreviewApp extends SfCommand<void> {
     sfdxProjectRootPath: string,
     serverPort: number,
     token: string,
-    username: string,
+    entityId: string,
     ldpServerUrl: string,
     appId: string | undefined,
     logger: Logger
@@ -261,9 +263,9 @@ export default class LightningPreviewApp extends SfCommand<void> {
       this.log(`\n${messages.getMessage('trust.local.dev.server')}`);
     }
 
-    const launchArguments = await PreviewUtils.generateDesktopPreviewLaunchArguments(
+    const launchArguments = PreviewUtils.generateDesktopPreviewLaunchArguments(
       ldpServerUrl,
-      username,
+      entityId,
       appId,
       targetOrg
     );
@@ -280,7 +282,7 @@ export default class LightningPreviewApp extends SfCommand<void> {
     sfdxProjectRootPath: string,
     serverPort: number,
     token: string,
-    username: string,
+    entityId: string,
     ldpServerUrl: string,
     appName: string | undefined,
     appId: string | undefined,
@@ -359,9 +361,9 @@ export default class LightningPreviewApp extends SfCommand<void> {
 
       // Launch the native app for previewing (launchMobileApp will show its own spinner)
       // eslint-disable-next-line camelcase
-      appConfig.launch_arguments = await PreviewUtils.generateMobileAppPreviewLaunchArguments(
+      appConfig.launch_arguments = PreviewUtils.generateMobileAppPreviewLaunchArguments(
         ldpServerUrl,
-        username,
+        entityId,
         appName,
         appId
       );

--- a/src/commands/lightning/preview/app.ts
+++ b/src/commands/lightning/preview/app.ts
@@ -190,13 +190,14 @@ export default class LightningPreviewApp extends SfCommand<void> {
     logger.debug(`Local Dev Server url is ${ldpServerUrl}`);
 
     if (platform === Platform.desktop) {
-      await this.desktopPreview(sfdxProjectRootPath, serverPort, token, ldpServerUrl, appId, logger);
+      await this.desktopPreview(sfdxProjectRootPath, serverPort, token, username, ldpServerUrl, appId, logger);
     } else {
       await this.mobilePreview(
         platform,
         sfdxProjectRootPath,
         serverPort,
         token,
+        username,
         ldpServerUrl,
         appName,
         appId,
@@ -210,6 +211,7 @@ export default class LightningPreviewApp extends SfCommand<void> {
     sfdxProjectRootPath: string,
     serverPort: number,
     token: string,
+    username: string,
     ldpServerUrl: string,
     appId: string | undefined,
     logger: Logger
@@ -242,7 +244,12 @@ export default class LightningPreviewApp extends SfCommand<void> {
       this.log(`\n${messages.getMessage('trust.local.dev.server')}`);
     }
 
-    const launchArguments = PreviewUtils.generateDesktopPreviewLaunchArguments(ldpServerUrl, token, appId, targetOrg);
+    const launchArguments = await PreviewUtils.generateDesktopPreviewLaunchArguments(
+      ldpServerUrl,
+      username,
+      appId,
+      targetOrg
+    );
 
     // Start the LWC Dev Server
     await startLWCServer(logger, sfdxProjectRootPath, token, serverPort);
@@ -256,6 +263,7 @@ export default class LightningPreviewApp extends SfCommand<void> {
     sfdxProjectRootPath: string,
     serverPort: number,
     token: string,
+    username: string,
     ldpServerUrl: string,
     appName: string | undefined,
     appId: string | undefined,
@@ -334,9 +342,9 @@ export default class LightningPreviewApp extends SfCommand<void> {
 
       // Launch the native app for previewing (launchMobileApp will show its own spinner)
       // eslint-disable-next-line camelcase
-      appConfig.launch_arguments = PreviewUtils.generateMobileAppPreviewLaunchArguments(
+      appConfig.launch_arguments = await PreviewUtils.generateMobileAppPreviewLaunchArguments(
         ldpServerUrl,
-        token,
+        username,
         appName,
         appId
       );

--- a/src/commands/lightning/preview/app.ts
+++ b/src/commands/lightning/preview/app.ts
@@ -21,7 +21,7 @@ import chalk from 'chalk';
 import { OrgUtils } from '../../../shared/orgUtils.js';
 import { startLWCServer } from '../../../lwc-dev-server/index.js';
 import { PreviewUtils } from '../../../shared/previewUtils.js';
-import { ConfigUtils } from '../../../shared/configUtils.js';
+import { AppServerIdentityTokenService, ConfigUtils } from '../../../shared/configUtils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'lightning.preview.app');
@@ -165,7 +165,8 @@ export default class LightningPreviewApp extends SfCommand<void> {
       return Promise.reject(new Error(messages.getMessage('error.username')));
     }
 
-    const token = await ConfigUtils.getOrCreateIdentityToken(username, connection);
+    const tokenService = new AppServerIdentityTokenService(connection);
+    const token = await ConfigUtils.getOrCreateIdentityToken(username, tokenService);
 
     let appId: string | undefined;
     if (appName) {

--- a/src/configMeta.ts
+++ b/src/configMeta.ts
@@ -27,10 +27,10 @@ export type SerializedSSLCertificateData = {
 
 export const enum ConfigVars {
   /**
-   * The Base64-encoded identity token of the local web server, used to
-   * validate the web server's identity to the hmr-client.
+   * The identity data is a data structure that ties together a single
+   * local web server identity token to multiple orgs.
    */
-  LOCAL_WEB_SERVER_IDENTITY_TOKEN = 'local-web-server-identity-token',
+  LOCAL_WEB_SERVER_IDENTITY_DATA = 'local-web-server-identity-data',
 
   /**
    * The SSL certificate data to be used by local dev server
@@ -50,7 +50,7 @@ export const enum ConfigVars {
 
 export default [
   {
-    key: ConfigVars.LOCAL_WEB_SERVER_IDENTITY_TOKEN,
+    key: ConfigVars.LOCAL_WEB_SERVER_IDENTITY_DATA,
     description: IDENTITY_TOKEN_DESC,
     hidden: true,
     encrypted: true,

--- a/src/configMeta.ts
+++ b/src/configMeta.ts
@@ -10,7 +10,7 @@ import { ConfigPropertyMeta, ConfigValue, Messages } from '@salesforce/core';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'shared.utils');
-const IDENTITY_TOKEN_DESC = messages.getMessage('config-utils.token-desc');
+const IDENTITY_DATA_DESC = messages.getMessage('config-utils.data-desc');
 const LOCAL_DEV_SERVER_CERT_DESC = messages.getMessage('config-utils.cert-desc');
 const LOCAL_DEV_SERVER_CERT_ERROR_MESSAGE = messages.getMessage('config-utils.cert-error-message');
 const LOCAL_DEV_SERVER_PORT_DESC = messages.getMessage('config-utils.port-desc');
@@ -27,8 +27,8 @@ export type SerializedSSLCertificateData = {
 
 export const enum ConfigVars {
   /**
-   * The identity data is a data structure that ties together a single
-   * local web server identity token to multiple orgs.
+   * The identity data is a data structure that links the local web server's
+   * identity token to the user's configured Salesforce orgs.
    */
   LOCAL_WEB_SERVER_IDENTITY_DATA = 'local-web-server-identity-data',
 
@@ -51,7 +51,7 @@ export const enum ConfigVars {
 export default [
   {
     key: ConfigVars.LOCAL_WEB_SERVER_IDENTITY_DATA,
-    description: IDENTITY_TOKEN_DESC,
+    description: IDENTITY_DATA_DESC,
     hidden: true,
     encrypted: true,
   },

--- a/src/lwc-dev-server/index.ts
+++ b/src/lwc-dev-server/index.ts
@@ -46,10 +46,10 @@ function mapLogLevel(cliLogLevel: number): number {
 async function createLWCServerConfig(
   logger: Logger,
   rootDir: string,
+  token: string,
   serverPort?: number,
   certData?: SSLCertificateData,
-  workspace?: Workspace,
-  token?: string
+  workspace?: Workspace
 ): Promise<ServerConfig> {
   const sfdxConfig = path.resolve(rootDir, 'sfdx-project.json');
 
@@ -83,7 +83,7 @@ async function createLWCServerConfig(
     paths: namespacePaths,
     // use custom workspace if any is provided, or fetch from config file (if any), otherwise use the default workspace
     workspace: workspace ?? (await ConfigUtils.getLocalDevServerWorkspace()) ?? LOCAL_DEV_SERVER_DEFAULT_WORKSPACE,
-    identityToken: token ?? (await ConfigUtils.getOrCreateIdentityToken()),
+    identityToken: token,
     logLevel: mapLogLevel(logger.getLevel()),
   };
 
@@ -100,12 +100,12 @@ async function createLWCServerConfig(
 export async function startLWCServer(
   logger: Logger,
   rootDir: string,
+  token: string,
   serverPort?: number,
   certData?: SSLCertificateData,
-  workspace?: Workspace,
-  token?: string
+  workspace?: Workspace
 ): Promise<LWCServer> {
-  const config = await createLWCServerConfig(logger, rootDir, serverPort, certData, workspace, token);
+  const config = await createLWCServerConfig(logger, rootDir, token, serverPort, certData, workspace);
 
   logger.trace(`Starting LWC Dev Server with config: ${JSON.stringify(config)}`);
   let lwcDevServer: LWCServer | null = await startLwcDevServer(config);

--- a/src/shared/configUtils.ts
+++ b/src/shared/configUtils.ts
@@ -7,29 +7,12 @@
 
 import { Workspace } from '@lwc/lwc-dev-server';
 import { CryptoUtils, SSLCertificateData } from '@salesforce/lwc-dev-mobile-core';
-import { Config, ConfigAggregator, Connection } from '@salesforce/core';
+import { Config, ConfigAggregator } from '@salesforce/core';
 import configMeta, { ConfigVars, SerializedSSLCertificateData } from './../configMeta.js';
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface IdentityTokenService {
+export type IdentityTokenService = {
   saveTokenToServer(token: string): Promise<string>;
-}
-
-export class AppServerIdentityTokenService implements IdentityTokenService {
-  private connection: Connection;
-  public constructor(connection: Connection) {
-    this.connection = connection;
-  }
-
-  public async saveTokenToServer(token: string): Promise<string> {
-    const sobject = this.connection.sobject('UserLocalWebServerIdentity');
-    const result = await sobject.insert({ LocalWebServerIdentityToken: token });
-    if (result.success) {
-      return result.id;
-    }
-    throw new Error('Could not save the token to the server');
-  }
-}
+};
 
 export const LOCAL_DEV_SERVER_DEFAULT_PORT = 8081;
 export const LOCAL_DEV_SERVER_DEFAULT_WORKSPACE = Workspace.SfCli;

--- a/src/shared/configUtils.ts
+++ b/src/shared/configUtils.ts
@@ -23,16 +23,16 @@ export type LocalWebServerIdentityData = {
 };
 
 export class ConfigUtils {
-  static #config: Config;
+  static #localConfig: Config;
   static #globalConfig: Config;
 
-  public static async getConfig(): Promise<Config> {
-    if (this.#config) {
-      return this.#config;
+  public static async getLocalConfig(): Promise<Config> {
+    if (this.#localConfig) {
+      return this.#localConfig;
     }
-    this.#config = await Config.create({ isGlobal: false });
+    this.#localConfig = await Config.create({ isGlobal: false });
     Config.addAllowedProperties(configMeta);
-    return this.#config;
+    return this.#localConfig;
   }
 
   public static async getGlobalConfig(): Promise<Config> {
@@ -65,7 +65,7 @@ export class ConfigUtils {
   }
 
   public static async writeIdentityData(identityData: LocalWebServerIdentityData): Promise<void> {
-    const config = await this.getConfig();
+    const config = await this.getLocalConfig();
     // TODO: JSON needs to be stringified in order for config.write to encrypt. When config.write()
     //       can encrypt JSON data to write it into config we shall remove stringify().
     config.set(ConfigVars.LOCAL_WEB_SERVER_IDENTITY_DATA, JSON.stringify(identityData));
@@ -73,7 +73,7 @@ export class ConfigUtils {
   }
 
   public static async getCertData(): Promise<SSLCertificateData | undefined> {
-    const config = await this.getConfig();
+    const config = await this.getLocalConfig();
     const serializedData = config.get(ConfigVars.LOCAL_DEV_SERVER_HTTPS_CERT_DATA) as SerializedSSLCertificateData;
     if (serializedData) {
       const deserializedData: SSLCertificateData = {
@@ -102,14 +102,14 @@ export class ConfigUtils {
   }
 
   public static async getLocalDevServerPort(): Promise<number | undefined> {
-    const config = await this.getConfig();
+    const config = await this.getLocalConfig();
     const configPort = config.get(ConfigVars.LOCAL_DEV_SERVER_PORT) as number;
 
     return configPort;
   }
 
   public static async getLocalDevServerWorkspace(): Promise<Workspace | undefined> {
-    const config = await this.getConfig();
+    const config = await this.getLocalConfig();
     const configWorkspace = config.get(ConfigVars.LOCAL_DEV_SERVER_WORKSPACE) as Workspace;
 
     return configWorkspace;

--- a/src/shared/configUtils.ts
+++ b/src/shared/configUtils.ts
@@ -57,9 +57,12 @@ export class ConfigUtils {
       await this.writeIdentityData(identityData);
       return token;
     } else {
-      const entityId = await tokenService.saveTokenToServer(identityData.identityToken);
-      identityData.usernameToServerEntityIdMap[username] = entityId;
-      await this.writeIdentityData(identityData);
+      let entityId = identityData.usernameToServerEntityIdMap[username];
+      if (!entityId) {
+        entityId = await tokenService.saveTokenToServer(identityData.identityToken);
+        identityData.usernameToServerEntityIdMap[username] = entityId;
+        await this.writeIdentityData(identityData);
+      }
       return identityData.identityToken;
     }
   }

--- a/src/shared/configUtils.ts
+++ b/src/shared/configUtils.ts
@@ -53,8 +53,7 @@ export class ConfigUtils {
       await this.writeIdentityData(identityData);
       return token;
     } else {
-      const existingEntityId = identityData.usernameToServerEntityIdMap[username];
-      const entityId = await this.saveIdentityTokenToServer(identityData.identityToken, connection, existingEntityId);
+      const entityId = await this.saveIdentityTokenToServer(identityData.identityToken, connection);
       identityData.usernameToServerEntityIdMap[username] = entityId;
       await this.writeIdentityData(identityData);
       return identityData.identityToken;
@@ -122,13 +121,9 @@ export class ConfigUtils {
     return undefined;
   }
 
-  private static async saveIdentityTokenToServer(
-    token: string,
-    connection: Connection,
-    entityId: string = ''
-  ): Promise<string> {
+  private static async saveIdentityTokenToServer(token: string, connection: Connection): Promise<string> {
     const sobject = connection.sobject('UserLocalWebServerIdentity');
-    const result = await sobject.upsert({ LocalWebServerIdentityToken: token, Id: `${entityId}` }, 'ID');
+    const result = await sobject.insert({ LocalWebServerIdentityToken: token });
     if (result.success) {
       return result.id;
     }

--- a/src/shared/previewUtils.ts
+++ b/src/shared/previewUtils.ts
@@ -162,6 +162,7 @@ export class PreviewUtils {
    * Generates the proper set of arguments to be used for launching desktop browser and navigating to the right location.
    *
    * @param ldpServerUrl The URL for the local dev server
+   * @param token The identity token used for web socket handshake
    * @param appId An optional app id for a targeted LEX app
    * @param targetOrg An optional org id
    * @param auraMode An optional Aura Mode (defaults to DEVPREVIEW)
@@ -169,6 +170,7 @@ export class PreviewUtils {
    */
   public static generateDesktopPreviewLaunchArguments(
     ldpServerUrl: string,
+    token: string,
     appId?: string,
     targetOrg?: string,
     auraMode = DevPreviewAuraMode
@@ -181,7 +183,10 @@ export class PreviewUtils {
     const appPath = appId ? `lightning/app/${appId}` : 'lightning';
 
     // we prepend a '0.' to all of the params to ensure they will persist across browser redirects
-    const launchArguments = ['--path', `${appPath}?0.aura.ldpServerUrl=${ldpServerUrl}&0.aura.mode=${auraMode}`];
+    const launchArguments = [
+      '--path',
+      `${appPath}?0.aura.ldpServerUrl=${ldpServerUrl}&0.aura.ldpServerId=${token}&0.aura.mode=${auraMode}`,
+    ];
 
     if (targetOrg) {
       launchArguments.push('--target-org', targetOrg);
@@ -194,6 +199,7 @@ export class PreviewUtils {
    * Generates the proper set of arguments to be used for launching a mobile app with custom launch arguments.
    *
    * @param ldpServerUrl The URL for the local dev server
+   * @param token The identity token used for web socket handshake
    * @param appName An optional app name for a targeted LEX app
    * @param appId An optional app id for a targeted LEX app
    * @param auraMode An optional Aura Mode (defaults to DEVPREVIEW)
@@ -201,6 +207,7 @@ export class PreviewUtils {
    */
   public static generateMobileAppPreviewLaunchArguments(
     ldpServerUrl: string,
+    token: string,
     appName?: string,
     appId?: string,
     auraMode = DevPreviewAuraMode
@@ -218,6 +225,8 @@ export class PreviewUtils {
     launchArguments.push({ name: '0.aura.ldpServerUrl', value: ldpServerUrl });
 
     launchArguments.push({ name: '0.aura.mode', value: auraMode });
+
+    launchArguments.push({ name: '0.aura.ldpServerId', value: token });
 
     return launchArguments;
   }

--- a/src/shared/previewUtils.ts
+++ b/src/shared/previewUtils.ts
@@ -162,27 +162,25 @@ export class PreviewUtils {
    * Generates the proper set of arguments to be used for launching desktop browser and navigating to the right location.
    *
    * @param ldpServerUrl The URL for the local dev server
-   * @param username User that is initiating the local preview
+   * @param entityId Record ID for the identity token
    * @param appId An optional app id for a targeted LEX app
    * @param targetOrg An optional org id
    * @param auraMode An optional Aura Mode (defaults to DEVPREVIEW)
    * @returns Array of arguments to be used by Org:Open command for launching desktop browser
    */
-  public static async generateDesktopPreviewLaunchArguments(
+  public static generateDesktopPreviewLaunchArguments(
     ldpServerUrl: string,
-    username: string,
+    entityId: string,
     appId?: string,
     targetOrg?: string,
     auraMode = DevPreviewAuraMode
-  ): Promise<string[]> {
+  ): string[] {
     // appPath will resolve to one of the following:
     //
     //   lightning/app/<appId> => when the user is targeting a specific LEX app
     //               lightning => when the user is not targeting a specific LEX app
     //
     const appPath = appId ? `lightning/app/${appId}` : 'lightning';
-
-    const entityId = await this.getEntityId(username);
 
     // we prepend a '0.' to all of the params to ensure they will persist across browser redirects
     const launchArguments = [
@@ -201,19 +199,19 @@ export class PreviewUtils {
    * Generates the proper set of arguments to be used for launching a mobile app with custom launch arguments.
    *
    * @param ldpServerUrl The URL for the local dev server
-   * @param username User that is initiating the local preview
+   * @param entityId Record ID for the identity token
    * @param appName An optional app name for a targeted LEX app
    * @param appId An optional app id for a targeted LEX app
    * @param auraMode An optional Aura Mode (defaults to DEVPREVIEW)
    * @returns Array of arguments to be used as custom launch arguments when launching a mobile app.
    */
-  public static async generateMobileAppPreviewLaunchArguments(
+  public static generateMobileAppPreviewLaunchArguments(
     ldpServerUrl: string,
-    username: string,
+    entityId: string,
     appName?: string,
     appId?: string,
     auraMode = DevPreviewAuraMode
-  ): Promise<LaunchArgument[]> {
+  ): LaunchArgument[] {
     const launchArguments: LaunchArgument[] = [];
 
     if (appName) {
@@ -227,8 +225,6 @@ export class PreviewUtils {
     launchArguments.push({ name: '0.aura.ldpServerUrl', value: ldpServerUrl });
 
     launchArguments.push({ name: '0.aura.mode', value: auraMode });
-
-    const entityId = await this.getEntityId(username);
 
     launchArguments.push({ name: '0.aura.ldpServerId', value: entityId });
 
@@ -509,7 +505,7 @@ export class PreviewUtils {
     await CommonUtils.executeCommandAsync(cmd, logger);
   }
 
-  private static async getEntityId(username: string): Promise<string> {
+  public static async getEntityId(username: string): Promise<string> {
     const identityData = await ConfigUtils.getIdentityData();
     let entityId: string | undefined;
     if (!identityData) {
@@ -517,7 +513,7 @@ export class PreviewUtils {
     } else {
       entityId = identityData.usernameToServerEntityIdMap[username];
       if (!entityId) {
-        return Promise.reject(messages.getMessage('error.identitydata.entityid'));
+        return Promise.reject(new Error(messages.getMessage('error.identitydata.entityid')));
       }
       return entityId;
     }

--- a/src/shared/previewUtils.ts
+++ b/src/shared/previewUtils.ts
@@ -513,11 +513,11 @@ export class PreviewUtils {
     const identityData = await ConfigUtils.getIdentityData();
     let entityId: string | undefined;
     if (!identityData) {
-      throw new Error(messages.getMessage('error.identitydata'));
+      return Promise.reject(new Error(messages.getMessage('error.identitydata')));
     } else {
       entityId = identityData.usernameToServerEntityIdMap[username];
       if (!entityId) {
-        throw new Error(messages.getMessage('error.identitydata.entityid'));
+        return Promise.reject(messages.getMessage('error.identitydata.entityid'));
       }
       return entityId;
     }

--- a/test/commands/lightning/preview/app.test.ts
+++ b/test/commands/lightning/preview/app.test.ts
@@ -25,6 +25,7 @@ import LightningPreviewApp, {
 } from '../../../../src/commands/lightning/preview/app.js';
 import { OrgUtils } from '../../../../src/shared/orgUtils.js';
 import { PreviewUtils } from '../../../../src/shared/previewUtils.js';
+import { ConfigUtils, LocalWebServerIdentityData } from '../../../../src/shared/configUtils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 
@@ -52,6 +53,14 @@ describe('lightning preview app', () => {
   const testEmulatorPort = 1234;
   let MockedLightningPreviewApp: typeof LightningPreviewApp;
 
+  const fakeIdentityToken = 'PFT1vw8v65aXd2b9HFvZ3Zu4OcKZwjI60bq7BEjj5k4=';
+  const fakeEntityId = '1I9xx0000004ClkCAE';
+  const fakeIdentityData: LocalWebServerIdentityData = {
+    identityToken: `${fakeIdentityToken}`,
+    usernameToServerEntityIdMap: {},
+  };
+  fakeIdentityData.usernameToServerEntityIdMap[testOrgData.username] = fakeEntityId;
+
   beforeEach(async () => {
     stubUx($$.SANDBOX);
     stubSpinner($$.SANDBOX);
@@ -62,6 +71,7 @@ describe('lightning preview app', () => {
     $$.SANDBOX.stub(SfConfig.prototype, 'get').returns(undefined);
     $$.SANDBOX.stub(SfConfig.prototype, 'set');
     $$.SANDBOX.stub(SfConfig.prototype, 'write').resolves();
+    $$.SANDBOX.stub(ConfigUtils, 'getOrCreateIdentityToken').resolves(fakeIdentityToken);
 
     MockedLightningPreviewApp = await esmock<typeof LightningPreviewApp>(
       '../../../../src/commands/lightning/preview/app.js',
@@ -112,6 +122,8 @@ describe('lightning preview app', () => {
     async function verifyOrgOpen(expectedAppPath: string, appName?: string): Promise<void> {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(fakeIdentityData);
+
       const runCmdStub = $$.SANDBOX.stub(OclifConfig.prototype, 'runCommand').resolves();
       if (appName) {
         await MockedLightningPreviewApp.run(['--name', appName, '-o', testOrgData.username]);
@@ -124,7 +136,7 @@ describe('lightning preview app', () => {
         'org:open',
         [
           '--path',
-          `${expectedAppPath}?0.aura.ldpServerUrl=${testServerUrl}&0.aura.mode=DEVPREVIEW`,
+          `${expectedAppPath}?0.aura.ldpServerUrl=${testServerUrl}&0.aura.ldpServerId=${fakeEntityId}&0.aura.mode=DEVPREVIEW`,
           '--target-org',
           testOrgData.username,
         ],
@@ -196,6 +208,7 @@ describe('lightning preview app', () => {
     it('waits for user to manually install the certificate', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(fakeIdentityData);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -272,6 +285,7 @@ describe('lightning preview app', () => {
     it('installs and launched app on mobile device', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(fakeIdentityData);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -413,8 +427,9 @@ describe('lightning preview app', () => {
       const expectedAppConfig =
         platform === Platform.ios ? iOSSalesforceAppPreviewConfig : androidSalesforceAppPreviewConfig;
       // eslint-disable-next-line camelcase
-      expectedAppConfig.launch_arguments = PreviewUtils.generateMobileAppPreviewLaunchArguments(
+      expectedAppConfig.launch_arguments = await PreviewUtils.generateMobileAppPreviewLaunchArguments(
         expectedLdpServerUrl,
+        testOrgData.username,
         'Sales',
         testAppId
       );

--- a/test/commands/lightning/preview/app.test.ts
+++ b/test/commands/lightning/preview/app.test.ts
@@ -7,7 +7,7 @@
 
 import path from 'node:path';
 import { Config as OclifConfig } from '@oclif/core';
-import { Config as SfConfig, Messages } from '@salesforce/core';
+import { Config as SfConfig, Messages, Connection } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import {
   AndroidVirtualDevice,
@@ -95,6 +95,16 @@ describe('lightning preview app', () => {
       expect(err)
         .to.be.an('error')
         .with.property('message', messages.getMessage('error.fetching.app-id', ['blah']));
+    }
+  });
+
+  it('throws when username not found', async () => {
+    try {
+      $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(undefined);
+      $$.SANDBOX.stub(Connection.prototype, 'getUsername').returns(undefined);
+      await MockedLightningPreviewApp.run(['--name', 'blah', '-o', testOrgData.username]);
+    } catch (err) {
+      expect(err).to.be.an('error').with.property('message', messages.getMessage('error.username'));
     }
   });
 

--- a/test/commands/lightning/preview/app.test.ts
+++ b/test/commands/lightning/preview/app.test.ts
@@ -158,6 +158,7 @@ describe('lightning preview app', () => {
     it('throws when environment setup requirements are not met', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(PreviewUtils, 'getEntityId').resolves(fakeEntityId);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').rejects(new Error('Requirement blah not met'));
@@ -169,6 +170,7 @@ describe('lightning preview app', () => {
     it('throws when unable to fetch mobile device', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(PreviewUtils, 'getEntityId').resolves(fakeEntityId);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -182,6 +184,7 @@ describe('lightning preview app', () => {
     it('throws when device fails to boot', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(PreviewUtils, 'getEntityId').resolves(fakeEntityId);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -199,6 +202,7 @@ describe('lightning preview app', () => {
     it('throws when cannot generate certificate', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(PreviewUtils, 'getEntityId').resolves(fakeEntityId);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -263,6 +267,7 @@ describe('lightning preview app', () => {
     it('throws if user chooses not to install app on mobile device', async () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
+      $$.SANDBOX.stub(PreviewUtils, 'getEntityId').resolves(fakeEntityId);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -296,6 +301,7 @@ describe('lightning preview app', () => {
       $$.SANDBOX.stub(OrgUtils, 'getAppId').resolves(testAppId);
       $$.SANDBOX.stub(PreviewUtils, 'generateWebSocketUrlForLocalDevServer').returns(testServerUrl);
       $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(fakeIdentityData);
+      $$.SANDBOX.stub(PreviewUtils, 'getEntityId').resolves(fakeEntityId);
 
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'init').resolves();
       $$.SANDBOX.stub(LwcDevMobileCoreSetup.prototype, 'run').resolves();
@@ -437,9 +443,9 @@ describe('lightning preview app', () => {
       const expectedAppConfig =
         platform === Platform.ios ? iOSSalesforceAppPreviewConfig : androidSalesforceAppPreviewConfig;
       // eslint-disable-next-line camelcase
-      expectedAppConfig.launch_arguments = await PreviewUtils.generateMobileAppPreviewLaunchArguments(
+      expectedAppConfig.launch_arguments = PreviewUtils.generateMobileAppPreviewLaunchArguments(
         expectedLdpServerUrl,
-        testOrgData.username,
+        fakeEntityId,
         'Sales',
         testAppId
       );

--- a/test/lwc-dev-server/index.e2e.test.ts
+++ b/test/lwc-dev-server/index.e2e.test.ts
@@ -46,8 +46,9 @@
 //     $$.SANDBOX.resetHistory();
 //   });
 
-//   it('e2e', async () => {
-//     const server = await devServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'));
+  it('e2e', async () => {
+//    const fakeIdentityToken = 'PFT1vw8v65aXd2b9HFvZ3Zu4OcKZwjI60bq7BEjj5k4=';
+//    const server = await devServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'), fakeIdentityToken);
 
 //     expect(server).to.be.an.instanceOf(LWCServer);
 //     server.stopServer();

--- a/test/lwc-dev-server/index.e2e.test.ts
+++ b/test/lwc-dev-server/index.e2e.test.ts
@@ -46,7 +46,7 @@
 //     $$.SANDBOX.resetHistory();
 //   });
 
-  it('e2e', async () => {
+//  it('e2e', async () => {
 //    const fakeIdentityToken = 'PFT1vw8v65aXd2b9HFvZ3Zu4OcKZwjI60bq7BEjj5k4=';
 //    const server = await devServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'), fakeIdentityToken);
 

--- a/test/lwc-dev-server/index.test.ts
+++ b/test/lwc-dev-server/index.test.ts
@@ -55,7 +55,8 @@ describe('lwc-dev-server', () => {
   });
 
   it('calling startLWCServer returns an LWCServer', async () => {
-    const s = await lwcDevServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'));
+    const fakeIdentityToken = 'PFT1vw8v65aXd2b9HFvZ3Zu4OcKZwjI60bq7BEjj5k4=';
+    const s = await lwcDevServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'), fakeIdentityToken);
     expect(s).to.equal(server);
   });
 });

--- a/test/shared/configUtils.test.ts
+++ b/test/shared/configUtils.test.ts
@@ -10,12 +10,7 @@ import { Workspace } from '@lwc/lwc-dev-server';
 import { Config, ConfigAggregator, Connection } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { CryptoUtils } from '@salesforce/lwc-dev-mobile-core';
-import {
-  ConfigUtils,
-  LOCAL_DEV_SERVER_DEFAULT_PORT,
-  LOCAL_DEV_SERVER_DEFAULT_WORKSPACE,
-  LocalWebServerIdentityData,
-} from '../../src/shared/configUtils.js';
+import { ConfigUtils, LocalWebServerIdentityData } from '../../src/shared/configUtils.js';
 import { ConfigVars } from '../../src/configMeta.js';
 
 describe('configUtils', () => {

--- a/test/shared/configUtils.test.ts
+++ b/test/shared/configUtils.test.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { expect } from 'chai';
 import { Workspace } from '@lwc/lwc-dev-server';
 import { Config, ConfigAggregator, Connection } from '@salesforce/core';
@@ -30,7 +28,10 @@ describe('configUtils', () => {
   });
 
   it('getOrCreateIdentityToken resolves if identity data is found', async () => {
-    const identityData = new LocalWebServerIdentityData(fakeIdentityToken);
+    const identityData: LocalWebServerIdentityData = {
+      identityToken: fakeIdentityToken,
+      usernameToServerEntityIdMap: {},
+    };
     identityData.usernameToServerEntityIdMap[username] = 'entityId';
     const stubConnection = $$.SANDBOX.createStubInstance(Connection);
     $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(identityData);
@@ -83,7 +84,11 @@ describe('configUtils', () => {
       $$.SANDBOX.match.string
     );
     $$.SANDBOX.stub(Config.prototype, 'write').resolves();
-    const identityData = new LocalWebServerIdentityData(fakeIdentityToken);
+    const identityData: LocalWebServerIdentityData = {
+      identityToken: fakeIdentityToken,
+      usernameToServerEntityIdMap: {},
+    };
+    identityData.usernameToServerEntityIdMap[username] = 'entityId';
 
     const resolved = await ConfigUtils.writeIdentityData(identityData);
     expect(resolved).to.equal(undefined);

--- a/test/shared/configUtils.test.ts
+++ b/test/shared/configUtils.test.ts
@@ -5,70 +5,87 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+
+
 import { expect } from 'chai';
 import { Workspace } from '@lwc/lwc-dev-server';
-import { Config, ConfigAggregator } from '@salesforce/core';
+import { Config, ConfigAggregator, Connection } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { CryptoUtils } from '@salesforce/lwc-dev-mobile-core';
-import { ConfigUtils } from '../../src/shared/configUtils.js';
+import {
+  ConfigUtils,
+  LOCAL_DEV_SERVER_DEFAULT_PORT,
+  LOCAL_DEV_SERVER_DEFAULT_WORKSPACE,
+  LocalWebServerIdentityData,
+} from '../../src/shared/configUtils.js';
 import { ConfigVars } from '../../src/configMeta.js';
 
 describe('configUtils', () => {
   const $$ = new TestContext();
+  const fakeIdentityToken = 'PFT1vw8v65aXd2b9HFvZ3Zu4OcKZwjI60bq7BEjj5k4=';
+  const username = 'SalesforceDeveloper';
 
   afterEach(() => {
     $$.restore();
   });
 
-  it('getOrCreateIdentityToken resolves if token is found', async () => {
-    const fakeIdentityToken = 'fake identity token';
-    $$.SANDBOX.stub(ConfigUtils, 'getIdentityToken').resolves(fakeIdentityToken);
+  it('getOrCreateIdentityToken resolves if identity data is found', async () => {
+    const identityData = new LocalWebServerIdentityData(fakeIdentityToken);
+    identityData.usernameToServerEntityIdMap[username] = 'entityId';
+    const stubConnection = $$.SANDBOX.createStubInstance(Connection);
+    $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(identityData);
+    $$.SANDBOX.stub(Connection, 'create').resolves(Connection.prototype);
 
-    const resolved = await ConfigUtils.getOrCreateIdentityToken();
+    const resolved = await ConfigUtils.getOrCreateIdentityToken(username, stubConnection);
+
     expect(resolved).to.equal(fakeIdentityToken);
   });
 
-  it('getOrCreateIdentityToken resolves and writeIdentityToken is called when there is no token', async () => {
-    const fakeIdentityToken = 'fake identity token';
-    $$.SANDBOX.stub(ConfigUtils, 'getIdentityToken').resolves(undefined);
+  it('getOrCreateIdentityToken resolves and writeIdentityData is called when there is no identity data', async () => {
+    const stubConnection = $$.SANDBOX.createStubInstance(Connection);
+    $$.SANDBOX.stub(ConfigUtils, 'getIdentityData').resolves(undefined);
     $$.SANDBOX.stub(CryptoUtils, 'generateIdentityToken').resolves(fakeIdentityToken);
-    const writeIdentityTokenStub = $$.SANDBOX.stub(ConfigUtils, 'writeIdentityToken').resolves();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $$.SANDBOX.stub(ConfigUtils as any, 'saveIdentityTokenToServer')
+      .withArgs(fakeIdentityToken, stubConnection)
+      .resolves('entityId');
+    const writeIdentityTokenStub = $$.SANDBOX.stub(ConfigUtils, 'writeIdentityData').resolves();
 
-    const resolved = await ConfigUtils.getOrCreateIdentityToken();
+    const resolved = await ConfigUtils.getOrCreateIdentityToken(username, stubConnection);
+
     expect(resolved).to.equal(fakeIdentityToken);
     expect(writeIdentityTokenStub.calledOnce).to.be.true;
   });
 
-  it('getIdentityToken resolves to undefined when identity token is not available', async () => {
+  it('getIdentityData resolves to undefined if identity data is not found', async () => {
     $$.SANDBOX.stub(ConfigAggregator, 'create').resolves(ConfigAggregator.prototype);
     $$.SANDBOX.stub(ConfigAggregator.prototype, 'reload').resolves();
     $$.SANDBOX.stub(ConfigAggregator.prototype, 'getPropertyValue').returns(undefined);
-    const resolved = await ConfigUtils.getIdentityToken();
 
+    const resolved = await ConfigUtils.getIdentityData();
     expect(resolved).to.equal(undefined);
   });
 
-  it('getIdentityToken resolves to a string when identity token is available', async () => {
-    const fakeIdentityToken = 'fake identity token';
+  it('getIdentityData resolves when identity data is available', async () => {
     $$.SANDBOX.stub(ConfigAggregator, 'create').resolves(ConfigAggregator.prototype);
     $$.SANDBOX.stub(ConfigAggregator.prototype, 'reload').resolves();
     $$.SANDBOX.stub(ConfigAggregator.prototype, 'getPropertyValue').returns(fakeIdentityToken);
 
-    const resolved = await ConfigUtils.getIdentityToken();
+    const resolved = await ConfigUtils.getIdentityData();
     expect(resolved).to.equal(fakeIdentityToken);
   });
 
-  it('writeIdentityToken resolves', async () => {
-    const fakeIdentityToken = 'fake identity token';
+  it('writeIdentityData resolves', async () => {
     $$.SANDBOX.stub(Config, 'create').withArgs($$.SANDBOX.match.any).resolves(Config.prototype);
     $$.SANDBOX.stub(Config, 'addAllowedProperties').withArgs($$.SANDBOX.match.any);
     $$.SANDBOX.stub(Config.prototype, 'set').withArgs(
-      ConfigVars.LOCAL_WEB_SERVER_IDENTITY_TOKEN,
+      ConfigVars.LOCAL_WEB_SERVER_IDENTITY_DATA,
       $$.SANDBOX.match.string
     );
     $$.SANDBOX.stub(Config.prototype, 'write').resolves();
+    const identityData = new LocalWebServerIdentityData(fakeIdentityToken);
 
-    const resolved = await ConfigUtils.writeIdentityToken(fakeIdentityToken);
+    const resolved = await ConfigUtils.writeIdentityData(identityData);
     expect(resolved).to.equal(undefined);
   });
 

--- a/test/shared/previewUtils.test.ts
+++ b/test/shared/previewUtils.test.ts
@@ -44,6 +44,9 @@ describe('previewUtils', () => {
     '34'
   );
 
+  const username = 'SalesforceDeveloper';
+  const entityId = '1I9xx0000004ClkCAE';
+
   afterEach(() => {
     $$.restore();
   });
@@ -107,22 +110,38 @@ describe('previewUtils', () => {
   });
 
   it('generateDesktopPreviewLaunchArguments', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $$.SANDBOX.stub(PreviewUtils as any, 'getEntityId')
+      .withArgs([username])
+      .resolves(entityId);
+
     expect(
-      PreviewUtils.generateDesktopPreviewLaunchArguments('MyLdpServerUrl', 'MyAppId', 'MyTargetOrg', 'MyAuraMode')
+      PreviewUtils.generateDesktopPreviewLaunchArguments(
+        'MyLdpServerUrl',
+        username,
+        'MyAppId',
+        'MyTargetOrg',
+        'MyAuraMode'
+      )
     ).to.deep.equal([
       '--path',
-      'lightning/app/MyAppId?0.aura.ldpServerUrl=MyLdpServerUrl&0.aura.mode=MyAuraMode',
+      `lightning/app/MyAppId?0.aura.ldpServerUrl=MyLdpServerUrl&0.aura.ldpServerId=${entityId}&0.aura.mode=MyAuraMode`,
       '--target-org',
       'MyTargetOrg',
     ]);
 
-    expect(PreviewUtils.generateDesktopPreviewLaunchArguments('MyLdpServerUrl')).to.deep.equal([
+    expect(PreviewUtils.generateDesktopPreviewLaunchArguments('MyLdpServerUrl', username)).to.deep.equal([
       '--path',
-      'lightning?0.aura.ldpServerUrl=MyLdpServerUrl&0.aura.mode=DEVPREVIEW',
+      `lightning?0.aura.ldpServerUrl=MyLdpServerUrl&0.aura.ldpServerId=${entityId}&0.aura.mode=DEVPREVIEW`,
     ]);
   });
 
   it('generateMobileAppPreviewLaunchArguments', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $$.SANDBOX.stub(PreviewUtils as any, 'getEntityId')
+      .withArgs([username])
+      .resolves(entityId);
+
     expect(
       PreviewUtils.generateMobileAppPreviewLaunchArguments('MyLdpServerUrl', 'MyAppName', 'MyAppId', 'MyAuraMode')
     ).to.deep.equal([
@@ -132,9 +151,10 @@ describe('previewUtils', () => {
       { name: '0.aura.mode', value: 'MyAuraMode' },
     ]);
 
-    expect(PreviewUtils.generateMobileAppPreviewLaunchArguments('MyLdpServerUrl')).to.deep.equal([
+    expect(PreviewUtils.generateMobileAppPreviewLaunchArguments('MyLdpServerUrl', username)).to.deep.equal([
       { name: '0.aura.ldpServerUrl', value: 'MyLdpServerUrl' },
       { name: '0.aura.mode', value: 'DEVPREVIEW' },
+      { name: '0.aura.ldpServerId', value: entityId },
     ]);
   });
 

--- a/test/shared/previewUtils.test.ts
+++ b/test/shared/previewUtils.test.ts
@@ -112,11 +112,11 @@ describe('previewUtils', () => {
   it('generateDesktopPreviewLaunchArguments', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     $$.SANDBOX.stub(PreviewUtils as any, 'getEntityId')
-      .withArgs([username])
+      .withArgs(username)
       .resolves(entityId);
 
     expect(
-      PreviewUtils.generateDesktopPreviewLaunchArguments(
+      await PreviewUtils.generateDesktopPreviewLaunchArguments(
         'MyLdpServerUrl',
         username,
         'MyAppId',
@@ -130,7 +130,7 @@ describe('previewUtils', () => {
       'MyTargetOrg',
     ]);
 
-    expect(PreviewUtils.generateDesktopPreviewLaunchArguments('MyLdpServerUrl', username)).to.deep.equal([
+    expect(await PreviewUtils.generateDesktopPreviewLaunchArguments('MyLdpServerUrl', username)).to.deep.equal([
       '--path',
       `lightning?0.aura.ldpServerUrl=MyLdpServerUrl&0.aura.ldpServerId=${entityId}&0.aura.mode=DEVPREVIEW`,
     ]);
@@ -139,19 +139,26 @@ describe('previewUtils', () => {
   it('generateMobileAppPreviewLaunchArguments', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     $$.SANDBOX.stub(PreviewUtils as any, 'getEntityId')
-      .withArgs([username])
+      .withArgs(username)
       .resolves(entityId);
 
     expect(
-      PreviewUtils.generateMobileAppPreviewLaunchArguments('MyLdpServerUrl', 'MyAppName', 'MyAppId', 'MyAuraMode')
+      await PreviewUtils.generateMobileAppPreviewLaunchArguments(
+        'MyLdpServerUrl',
+        username,
+        'MyAppName',
+        'MyAppId',
+        'MyAuraMode'
+      )
     ).to.deep.equal([
       { name: 'LightningExperienceAppName', value: 'MyAppName' },
       { name: 'LightningExperienceAppID', value: 'MyAppId' },
       { name: '0.aura.ldpServerUrl', value: 'MyLdpServerUrl' },
       { name: '0.aura.mode', value: 'MyAuraMode' },
+      { name: '0.aura.ldpServerId', value: entityId },
     ]);
 
-    expect(PreviewUtils.generateMobileAppPreviewLaunchArguments('MyLdpServerUrl', username)).to.deep.equal([
+    expect(await PreviewUtils.generateMobileAppPreviewLaunchArguments('MyLdpServerUrl', username)).to.deep.equal([
       { name: '0.aura.ldpServerUrl', value: 'MyLdpServerUrl' },
       { name: '0.aura.mode', value: 'DEVPREVIEW' },
       { name: '0.aura.ldpServerId', value: entityId },


### PR DESCRIPTION
### What does this PR do?
* Saves identity data structure in `sf`'s config
* Saves identity token on server

### What issues does this PR fix or reference?

@W-15428971@