### PR TITLE
@W-16207529@ fix: shoring up test running functionality

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
         "focus": false,
         "panel": "dedicated"
       },
-      "args": ["run", "pretest"],
+      "args": ["test:compile"],
       "isBackground": false
     }
   ]

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "test": "wireit",
+    "test:compile": "wireit",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
     "test:only": "wireit",
     "unlink-lwr": "yarn unlink @lwrjs/api @lwrjs/app-service @lwrjs/asset-registry @lwrjs/asset-transformer @lwrjs/auth-middleware @lwrjs/base-view-provider @lwrjs/base-view-transformer @lwrjs/client-modules @lwrjs/config @lwrjs/core @lwrjs/dev-proxy-server @lwrjs/diagnostics @lwrjs/esbuild @lwrjs/everywhere @lwrjs/fs-asset-provider @lwrjs/fs-watch @lwrjs/html-view-provider @lwrjs/instrumentation @lwrjs/label-module-provider @lwrjs/lambda @lwrjs/legacy-npm-module-provider @lwrjs/loader @lwrjs/lwc-module-provider @lwrjs/lwc-ssr @lwrjs/markdown-view-provider @lwrjs/module-bundler @lwrjs/module-registry @lwrjs/npm-module-provider @lwrjs/nunjucks-view-provider @lwrjs/o11y @lwrjs/resource-registry @lwrjs/router @lwrjs/security @lwrjs/server @lwrjs/shared-utils @lwrjs/static @lwrjs/tools @lwrjs/types @lwrjs/view-registry lwr",

--- a/test/lwc-dev-server/index.e2e.test.ts
+++ b/test/lwc-dev-server/index.e2e.test.ts
@@ -5,47 +5,52 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { expect } from 'chai';
-import sinon from 'sinon';
-import { Logger } from '@salesforce/core';
-import { TestContext } from '@salesforce/core/testSetup';
-import { LWCServer, Workspace } from '@lwc/lwc-dev-server';
-import * as devServer from '../../src/lwc-dev-server/index.js';
-import { ConfigUtils } from '../../src/shared/configUtils.js';
+// **
+// * Commenting out this test file until lwc-dev-server's `stopServer()`
+// * can be fixed to not process.exit(0), as it negatively impacts our
+// * test runs.
+// **
+// import path from 'node:path';
+// import { fileURLToPath } from 'node:url';
+// import { expect } from 'chai';
+// import sinon from 'sinon';
+// import { Logger } from '@salesforce/core';
+// import { TestContext } from '@salesforce/core/testSetup';
+// import { LWCServer, Workspace } from '@lwc/lwc-dev-server';
+// import * as devServer from '../../src/lwc-dev-server/index.js';
+// import { ConfigUtils } from '../../src/shared/configUtils.js';
 
-// eslint-disable-next-line no-underscore-dangle
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const logger = {
-  debug: () => {},
-  warn: () => {},
-  trace: () => {},
-  getLevel: () => 10,
-} as Logger;
+// // eslint-disable-next-line no-underscore-dangle
+// const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// const logger = {
+//   debug: () => {},
+//   warn: () => {},
+//   trace: () => {},
+//   getLevel: () => 10,
+// } as Logger;
 
-describe('lwc-dev-server e2e', () => {
-  const $$ = new TestContext();
-  let processExitSpy: sinon.SinonSpy;
+// describe('lwc-dev-server e2e', () => {
+//   const $$ = new TestContext();
+//   let processExitSpy: sinon.SinonSpy;
 
-  beforeEach(() => {
-    processExitSpy = $$.SANDBOX.stub(process, 'exit');
-    $$.SANDBOX.stub(ConfigUtils, 'getOrCreateIdentityToken').resolves('testIdentityToken');
-    $$.SANDBOX.stub(ConfigUtils, 'getLocalDevServerPort').resolves(1234);
-    $$.SANDBOX.stub(ConfigUtils, 'getLocalDevServerWorkspace').resolves(Workspace.SfCli);
-    $$.SANDBOX.stub(ConfigUtils, 'getCertData').resolves(undefined);
-  });
+//   beforeEach(() => {
+//     processExitSpy = $$.SANDBOX.stub(process, 'exit');
+//     $$.SANDBOX.stub(ConfigUtils, 'getOrCreateIdentityToken').resolves('testIdentityToken');
+//     $$.SANDBOX.stub(ConfigUtils, 'getLocalDevServerPort').resolves(1234);
+//     $$.SANDBOX.stub(ConfigUtils, 'getLocalDevServerWorkspace').resolves(Workspace.SfCli);
+//     $$.SANDBOX.stub(ConfigUtils, 'getCertData').resolves(undefined);
+//   });
 
-  afterEach(() => {
-    $$.restore();
-    $$.SANDBOX.resetHistory();
-  });
+//   afterEach(() => {
+//     $$.restore();
+//     $$.SANDBOX.resetHistory();
+//   });
 
-  it('e2e', async () => {
-    const server = await devServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'));
+//   it('e2e', async () => {
+//     const server = await devServer.startLWCServer(logger, path.resolve(__dirname, './__mocks__'));
 
-    expect(server).to.be.an.instanceOf(LWCServer);
-    server.stopServer();
-    expect(processExitSpy.calledWith(0)).to.be.true;
-  });
-});
+//     expect(server).to.be.an.instanceOf(LWCServer);
+//     server.stopServer();
+//     expect(processExitSpy.calledWith(0)).to.be.true;
+//   });
+// });

--- a/test/shared/previewUtils.test.ts
+++ b/test/shared/previewUtils.test.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
 import { TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import {
@@ -149,15 +150,16 @@ describe('previewUtils', () => {
     $$.SANDBOX.stub(fs, 'existsSync').returns(false);
     $$.SANDBOX.stub(fs, 'writeFileSync').returns();
 
-    let result = await PreviewUtils.generateSelfSignedCert(Platform.ios, '/path/to/dir');
-    expect(result.certFilePath).to.be.equal('/path/to/dir/localhost.der');
+    const certDirPath = '/path/to/dir';
+    let result = await PreviewUtils.generateSelfSignedCert(Platform.ios, certDirPath);
+    expect(result.certFilePath).to.be.equal(path.join(path.resolve(certDirPath), 'localhost.der'));
     expect(result.certData.derCertificate.toString('utf8')).to.be.equal('testDERCert');
     expect(result.certData.pemCertificate).to.be.equal('testPEMCert');
     expect(result.certData.pemPrivateKey).to.be.equal('testPrivateKey');
     expect(result.certData.pemPublicKey).to.be.equal('testPublicKey');
 
-    result = await PreviewUtils.generateSelfSignedCert(Platform.android, '/path/to/dir');
-    expect(result.certFilePath).to.be.equal('/path/to/dir/localhost.pem');
+    result = await PreviewUtils.generateSelfSignedCert(Platform.android, certDirPath);
+    expect(result.certFilePath).to.be.equal(path.join(path.resolve(certDirPath), 'localhost.pem'));
     expect(result.certData.derCertificate.toString('utf8')).to.be.equal('testDERCert');
     expect(result.certData.pemCertificate).to.be.equal('testPEMCert');
     expect(result.certData.pemPrivateKey).to.be.equal('testPrivateKey');


### PR DESCRIPTION
### What does this PR do?

- Commented out the test in index.e2e.test.ts that calls lwc-dev-server's stopServer(), since that's erroneously exiting the calling process and making all the tests "pass", whether they're successful or not.
- Fixed tasks.json to call our existing test compilation, so we can run tests from VSCode.

### What issues does this PR fix or reference?
@W-16207529@ - Issues with test runs always succeeding, even with failures.