### PR TITLE
chore: only trigger release on demand

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,12 +1,12 @@
 name: create-github-release
 
 on:
-  push:
-    branches:
-      - main
-      - prerelease/**
-    tags-ignore:
-      - '*'
+#  push:
+#    branches:
+#      - main
+#      - prerelease/**
+#    tags-ignore:
+#      - '*'
   workflow_dispatch:
     inputs:
       prerelease:


### PR DESCRIPTION
### What does this PR do?
Update the create-github-release action to only publish on demand for now. This will avoid unintentional publishes until we are ready for the official release of the plugin

### What issues does this PR fix or reference?
@W-16499669@
