### PR TITLE
chore: setup CI for npm publish

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -25,7 +25,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
     needs: [getDistTag]
     with:
-      ctc: true
+      #ctc: true
       sign: true
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}


### PR DESCRIPTION
### What does this PR do?
Attempting to setup CI for publishing. CTC causes npm publish to be skipped currently, so seeing if this will fix it for us.

### What issues does this PR fix or reference?
@W-16499669@
