### PR TITLE
feat: establish valid experience site sessions at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ EXAMPLES
     $ sf lightning dev app --target-org myOrg --device-type ios --device-id "iPhone 15 Pro Max"
 ```
 
-_See code: [src/commands/lightning/dev/app.ts](https://github.com/salesforcecli/plugin-lightning-dev/blob/1.2.0/src/commands/lightning/dev/app.ts)_
+_See code: [src/commands/lightning/dev/app.ts](https://github.com/salesforcecli/plugin-lightning-dev/blob/1.2.1-alpha.0/src/commands/lightning/dev/app.ts)_
 
 ## `sf lightning dev site`
 
@@ -244,6 +244,6 @@ EXAMPLES
     $ sf lightning dev site --name "Partner Central" --target-org myOrg
 ```
 
-_See code: [src/commands/lightning/dev/site.ts](https://github.com/salesforcecli/plugin-lightning-dev/blob/1.2.0/src/commands/lightning/dev/site.ts)_
+_See code: [src/commands/lightning/dev/site.ts](https://github.com/salesforcecli/plugin-lightning-dev/blob/1.2.1-alpha.0/src/commands/lightning/dev/site.ts)_
 
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-lightning-dev",
   "description": "Lightning development tools for LEX, Mobile, and Experience Sites",
-  "version": "1.2.0",
+  "version": "1.2.1-alpha.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@salesforce/sf-plugins-core": "^11.2.4",
     "@inquirer/select": "^2.4.7",
     "@inquirer/prompts": "^5.3.8",
+    "axios": "^1.7.7",
     "chalk": "^5.3.0",
     "lwc": "7.1.3",
     "lwr": "0.14.2",

--- a/src/commands/lightning/dev/site.ts
+++ b/src/commands/lightning/dev/site.ts
@@ -64,15 +64,12 @@ export default class LightningDevSite extends SfCommand<void> {
         }
       }
 
-      // Pass the org auth token so LWR can make authenticated requests to core
-      const authToken = org.getConnection().accessToken ?? '';
-
-      const networkId = await selectedSite.getNetworkIdByName();
-      const sidToken = await selectedSite.getNewSidToken(networkId);
+      // Establish a valid access token for this site
+      const authToken = await selectedSite.setupAuth();
 
       // Start the dev server
       await expDev({
-        authToken: sidToken || authToken,
+        authToken,
         open: true,
         port: 3000,
         logLevel: 'error',

--- a/src/commands/lightning/dev/site.ts
+++ b/src/commands/lightning/dev/site.ts
@@ -67,9 +67,12 @@ export default class LightningDevSite extends SfCommand<void> {
       // Pass the org auth token so LWR can make authenticated requests to core
       const authToken = org.getConnection().accessToken ?? '';
 
+      const networkId = await selectedSite.getNetworkIdByName();
+      const sidToken = await selectedSite.getNewSidToken(networkId);
+
       // Start the dev server
       await expDev({
-        authToken,
+        authToken: sidToken || authToken,
         open: true,
         port: 3000,
         logLevel: 'error',

--- a/src/shared/experience/expSite.ts
+++ b/src/shared/experience/expSite.ts
@@ -96,15 +96,6 @@ export class ExperienceSite {
   }
 
   /**
-   * Steps to init:
-   * 1) Verify the site is an actual site within this organization
-   * 2) Verify and output specific message if wrong site type is selected
-   * 2) Verify that site has been published with Local Dev perm enabled (i.e. a static resource exists for this site name)
-   * 3) Establish sid token for proxied requests
-   */
-  // public async init(): Promise<void> {}
-
-  /**
    * Esablish a valid token for this local development session
    *
    * @returns sid token for proxied site requests

--- a/src/shared/experience/expSite.ts
+++ b/src/shared/experience/expSite.ts
@@ -333,6 +333,8 @@ export class ExperienceSite {
 
       return ''; // Site will be guest user access only
     }
+
+    // Not sure what scenarios we don't have an access token at all, but lets output a separate message here so we can distinguish these edge cases
     // eslint-disable-next-line no-console
     console.warn(
       'Warning: sf cli org connection missing accessToken. Local Dev proxied requests to your site may fail or return data from the guest user context.'

--- a/src/shared/experience/expSite.ts
+++ b/src/shared/experience/expSite.ts
@@ -275,14 +275,13 @@ export class ExperienceSite {
     const accessToken = conn.accessToken;
     const instanceUrl = conn.instanceUrl; // Org URL
 
-    // Call out to the servlet to establish a session
-    const switchUrl = `${instanceUrl}/servlet/networks/switch?networkId=${networkId}`;
-
     // Make the GET request without following redirects
     if (accessToken) {
       // TODO should we try and refresh auth here?
       // await conn.refreshAuth();
 
+      // Call out to the switcher servlet to establish a session
+      const switchUrl = `${instanceUrl}/servlet/networks/switch?networkId=${networkId}`;
       const cookies = [`sid=${accessToken}`, `oid=${orgIdMinus3}`].join('; ').trim();
       let response = await axios.get(switchUrl, {
         headers: {
@@ -293,7 +292,7 @@ export class ExperienceSite {
         validateStatus: (status) => status >= 200 && status < 400, // Accept 3xx status codes
       });
 
-      // Extract the Location header
+      // Extract the Location callback header
       const locationHeader = response.headers['location'] as string;
       if (locationHeader) {
         // Parse the URL to extract the 'sid' parameter

--- a/yarn.lock
+++ b/yarn.lock
@@ -6126,6 +6126,15 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.0.tgz#d9e56ab0147278272739a000880196cdfe113b59"
   integrity sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==
 
+axios@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.4.tgz#6dfba930294ea14d7d2fc68b9d007211baedb94c"
@@ -8694,6 +8703,11 @@ follow-redirects@^1.0.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -12990,6 +13004,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
### What does this PR do?
- On local-dev startup, simulate the auth flow for establishing a valid SID token for sites via servlets (`/servlet/networks/switch`). Grab the valid token from those requests and append to any proxied requests back to core for the life of the local development session. Requests in the browser may still show asGuest=true but be proxied to your org with valid authentication credentials by the dev server. 

- Create a new environment variable `SITE_GUEST_ACCESS`. When set to true, this will skip attempting to establish a valid authentication session at startup and allow you to access the site as a guest user. 

**Note: This is more of a temporary solution to support sites auth and may evolve as we update the Beta and work towards GA**  

### What issues does this PR fix or reference?
@W-16647027@