### PR TITLE
feat: ensure local dev is enabled for an org

### DIFF
--- a/messages/lightning.dev.app.md
+++ b/messages/lightning.dev.app.md
@@ -35,10 +35,6 @@ ID of the mobile device to display the preview if device type is set to `ios` or
 
 Org must have a valid user
 
-# error.localdev.not.enabled
-
-Local Dev is not enabled for your org. See https://developer.salesforce.com/docs/platform/lwc/guide/get-started-test-components.html for more information on enabling and using Local Dev.
-
 # error.identitydata
 
 Couldn't find identity data while generating preview arguments

--- a/messages/lightning.dev.app.md
+++ b/messages/lightning.dev.app.md
@@ -35,6 +35,10 @@ ID of the mobile device to display the preview if device type is set to `ios` or
 
 Org must have a valid user
 
+# error.localdev.not.enabled
+
+Local Dev is not enabled for your org. See https://developer.salesforce.com/docs/platform/lwc/guide/get-started-test-components.html for more information on enabling and using Local Dev.
+
 # error.identitydata
 
 Couldn't find identity data while generating preview arguments

--- a/messages/shared.utils.md
+++ b/messages/shared.utils.md
@@ -25,3 +25,7 @@ The SSL certificate data to be used by the local dev server for secure connectio
 # config-utils.cert-error-message
 
 You must provide valid SSL certificate data
+
+# error.localdev.not.enabled
+
+Local Dev is not enabled for your org. See https://developer.salesforce.com/docs/platform/lwc/guide/get-started-test-components.html for more information on enabling and using Local Dev.

--- a/src/commands/lightning/dev/app.ts
+++ b/src/commands/lightning/dev/app.ts
@@ -101,6 +101,11 @@ export default class LightningDevApp extends SfCommand<void> {
       return Promise.reject(new Error(messages.getMessage('error.username')));
     }
 
+    const localDevEnabled = await OrgUtils.isLocalDevEnabled(connection);
+    if (!localDevEnabled) {
+      return Promise.reject(new Error(messages.getMessage('error.localdev.not.enabled')));
+    }
+
     const tokenService = new AppServerIdentityTokenService(connection);
     const token = await ConfigUtils.getOrCreateIdentityToken(username, tokenService);
 

--- a/src/commands/lightning/dev/app.ts
+++ b/src/commands/lightning/dev/app.ts
@@ -24,6 +24,7 @@ import { ConfigUtils, IdentityTokenService } from '../../../shared/configUtils.j
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'lightning.dev.app');
+const sharedMessages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'shared.utils');
 
 export const iOSSalesforceAppPreviewConfig = {
   name: 'Salesforce Mobile App',
@@ -103,7 +104,7 @@ export default class LightningDevApp extends SfCommand<void> {
 
     const localDevEnabled = await OrgUtils.isLocalDevEnabled(connection);
     if (!localDevEnabled) {
-      return Promise.reject(new Error(messages.getMessage('error.localdev.not.enabled')));
+      return Promise.reject(new Error(sharedMessages.getMessage('error.localdev.not.enabled')));
     }
 
     const tokenService = new AppServerIdentityTokenService(connection);

--- a/src/commands/lightning/dev/site.ts
+++ b/src/commands/lightning/dev/site.ts
@@ -8,11 +8,13 @@ import fs from 'node:fs';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { expDev } from '@lwrjs/api';
+import { OrgUtils } from '../../../shared/orgUtils.js';
 import { PromptUtils } from '../../../shared/prompt.js';
 import { ExperienceSite } from '../../../shared/experience/expSite.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'lightning.dev.site');
+const sharedMessages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'shared.utils');
 
 export default class LightningDevSite extends SfCommand<void> {
   public static readonly summary = messages.getMessage('summary');
@@ -34,6 +36,11 @@ export default class LightningDevSite extends SfCommand<void> {
     try {
       const org = flags['target-org'];
       let siteName = flags.name;
+
+      const localDevEnabled = await OrgUtils.isLocalDevEnabled(org.getConnection(undefined));
+      if (!localDevEnabled) {
+        throw new Error(sharedMessages.getMessage('error.localdev.not.enabled'));
+      }
 
       // If user doesn't specify a site, prompt the user for one
       if (!siteName) {

--- a/src/shared/orgUtils.ts
+++ b/src/shared/orgUtils.ts
@@ -38,4 +38,20 @@ export class OrgUtils {
 
     return undefined;
   }
+
+  /**
+   * Checks to see if Local Dev is enabled for the org.
+   *
+   * @param connection the connection to the org
+   * @returns boolean indicating whether Local Dev is enabled for the org.
+   */
+  public static async isLocalDevEnabled(connection: Connection): Promise<boolean> {
+    const metadata = await connection.metadata.read('LightningExperienceSettings', 'enableLightningPreviewPref');
+    // casting to any here b/c LightningExperienceSettings type which is defined in 'jsforce'
+    // does not contain a definition for enableLightningPreviewPref.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const flagValue = `${(metadata as any).enableLightningPreviewPref}`;
+    const localDevEnabled = flagValue.toLowerCase().trim() === 'true';
+    return localDevEnabled;
+  }
 }

--- a/src/shared/orgUtils.ts
+++ b/src/shared/orgUtils.ts
@@ -7,6 +7,10 @@
 
 import { Connection } from '@salesforce/core';
 
+type LightningPreviewMetadataResponse = {
+  enableLightningPreviewPref?: string;
+};
+
 export class OrgUtils {
   /**
    * Given an app name, it queries the org to find the matching app id. To do so,
@@ -47,10 +51,7 @@ export class OrgUtils {
    */
   public static async isLocalDevEnabled(connection: Connection): Promise<boolean> {
     const metadata = await connection.metadata.read('LightningExperienceSettings', 'enableLightningPreviewPref');
-    // casting to any here b/c LightningExperienceSettings type which is defined in 'jsforce'
-    // does not contain a definition for enableLightningPreviewPref.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    const flagValue = `${(metadata as any).enableLightningPreviewPref}`;
+    const flagValue = (metadata as LightningPreviewMetadataResponse).enableLightningPreviewPref ?? 'false';
     const localDevEnabled = flagValue.toLowerCase().trim() === 'true';
     return localDevEnabled;
   }

--- a/test/commands/lightning/dev/app.test.ts
+++ b/test/commands/lightning/dev/app.test.ts
@@ -37,6 +37,7 @@ Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 
 describe('lightning dev app', () => {
   const messages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'lightning.dev.app');
+  const sharedMessages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'shared.utils');
   const $$ = new TestContext();
   const testOrgData = new MockTestOrgData();
   const testAppId = '06m8b000002vpFSAAY';
@@ -102,7 +103,7 @@ describe('lightning dev app', () => {
       $$.SANDBOX.stub(OrgUtils, 'isLocalDevEnabled').resolves(false);
       await MockedLightningPreviewApp.run(['--name', 'blah', '-o', testOrgData.username]);
     } catch (err) {
-      expect(err).to.be.an('error').with.property('message', messages.getMessage('error.localdev.not.enabled'));
+      expect(err).to.be.an('error').with.property('message', sharedMessages.getMessage('error.localdev.not.enabled'));
     }
   });
 


### PR DESCRIPTION
### What does this PR do?
Update the `lightning:dev:app` command to first check and see whether Local Dev is enabled for an org or not before proceeding with the local preview.

### What issues does this PR fix or reference?
@W-16591156@