### PR TITLE
feat: prompt user to select lightning experince app

### DIFF
--- a/messages/prompts.md
+++ b/messages/prompts.md
@@ -6,6 +6,10 @@ Select a site
 
 An updated site bundle is available for "%s". Do you want to download and apply the update?
 
+# lightning-experience-app.title
+
+Which Lightning Experience App do you want to use for the preview?
+
 # device-type.title
 
 Which device type do you want to use for the preview?

--- a/src/commands/lightning/dev/app.ts
+++ b/src/commands/lightning/dev/app.ts
@@ -97,19 +97,7 @@ export default class LightningDevApp extends SfCommand<void> {
       return Promise.reject(new Error(messages.getMessage('error.identitydata.entityid')));
     }
 
-    let appId: string | undefined;
-    if (appName) {
-      logger.debug(`Determining App Id for ${appName}`);
-
-      // The appName is optional but if the user did provide an appName then it must be
-      // a valid one.... meaning that it should resolve to a valid appId.
-      appId = await OrgUtils.getAppId(connection, appName);
-      if (!appId) {
-        return Promise.reject(new Error(messages.getMessage('error.fetching.app-id', [appName])));
-      }
-
-      logger.debug(`App Id is ${appId}`);
-    }
+    const appId = await PreviewUtils.getLightningExperienceAppId(connection, appName, logger);
 
     logger.debug('Determining the next available port for Local Dev Server');
     const serverPorts = await PreviewUtils.getNextAvailablePorts();

--- a/src/shared/promptUtils.ts
+++ b/src/shared/promptUtils.ts
@@ -6,7 +6,7 @@
  */
 import select from '@inquirer/select';
 import { confirm } from '@inquirer/prompts';
-import { Logger, Messages } from '@salesforce/core';
+import { Connection, Logger, Messages } from '@salesforce/core';
 import {
   AndroidDeviceManager,
   AppleDeviceManager,
@@ -14,6 +14,7 @@ import {
   Platform,
   Version,
 } from '@salesforce/lwc-dev-mobile-core';
+import { AppDefinition, OrgUtils } from './orgUtils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-lightning-dev', 'prompts');
@@ -45,6 +46,18 @@ export class PromptUtils {
 
     const response = await select({
       message: messages.getMessage('device-type.title'),
+      choices,
+    });
+
+    return response;
+  }
+
+  public static async promptUserToSelectLightningExperienceApp(connection: Connection): Promise<AppDefinition> {
+    const apps = await OrgUtils.getLightningExperienceAppList(connection);
+    const choices = apps.map((app) => ({ name: app.Label, value: app }));
+
+    const response = await select({
+      message: messages.getMessage('lightning-experience-app.title'),
       choices,
     });
 

--- a/test/shared/orgUtils.test.ts
+++ b/test/shared/orgUtils.test.ts
@@ -17,23 +17,23 @@ describe('orgUtils', () => {
     $$.restore();
   });
 
-  it('getAppId returns undefined when no matches found', async () => {
+  it('getAppDefinitionDurableId returns undefined when no matches found', async () => {
     $$.SANDBOX.stub(Connection.prototype, 'query').resolves({ records: [], done: true, totalSize: 0 });
-    const appId = await OrgUtils.getAppId(new Connection({ authInfo: new AuthInfo() }), 'blah');
+    const appId = await OrgUtils.getAppDefinitionDurableId(new Connection({ authInfo: new AuthInfo() }), 'blah');
     expect(appId).to.be.undefined;
   });
 
-  it('getAppId returns first match when multiple matches found', async () => {
+  it('getAppDefinitionDurableId returns first match when multiple matches found', async () => {
     $$.SANDBOX.stub(Connection.prototype, 'query').resolves({
       records: [{ DurableId: 'id1' }, { DurableId: 'id2' }],
       done: true,
       totalSize: 2,
     });
-    const appId = await OrgUtils.getAppId(new Connection({ authInfo: new AuthInfo() }), 'Sales');
+    const appId = await OrgUtils.getAppDefinitionDurableId(new Connection({ authInfo: new AuthInfo() }), 'Sales');
     expect(appId).to.be.equal('id1');
   });
 
-  it('getAppId uses Label if DeveloperName produces no matches', async () => {
+  it('getAppDefinitionDurableId uses Label if DeveloperName produces no matches', async () => {
     const noMatches = { records: [], done: true, totalSize: 0 };
     const matches = { records: [{ DurableId: 'id1' }, { DurableId: 'id2' }], done: true, totalSize: 2 };
     const stub = $$.SANDBOX.stub(Connection.prototype, 'query')
@@ -41,7 +41,7 @@ describe('orgUtils', () => {
       .resolves(noMatches)
       .onSecondCall()
       .resolves(matches);
-    const appId = await OrgUtils.getAppId(new Connection({ authInfo: new AuthInfo() }), 'Sales');
+    const appId = await OrgUtils.getAppDefinitionDurableId(new Connection({ authInfo: new AuthInfo() }), 'Sales');
     expect(appId).to.be.equal('id1');
     expect(stub.getCall(0).args[0]).to.include('DeveloperName');
     expect(stub.getCall(1).args[0]).to.include('Label');


### PR DESCRIPTION
What does this PR do?
If no value is provided for the flag `--name` then interactively prompts the user to select a lightning experience app.

What issues does this PR fix or reference?
@W-16599797@