### PR TITLE
feat: add parameter for browser to open preview in

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ USAGE
   $ sf lightning dev app -o <value> [--flags-dir <value>] [-n <value>] [-t desktop|ios|android] [-i <value>]
 
 FLAGS
+  -b, --browser=<option>      Browser to open the url in when previewing on desktop.
+                              <options: chrome|edge|firefox>
   -i, --device-id=<value>     ID of the mobile device to display the preview if device type is set to `ios` or
                               `android`. The default value is the ID of the first available mobile device.
   -n, --name=<value>          Name of the Lightning Experience app to preview.

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -3,8 +3,8 @@
     "alias": [],
     "command": "lightning:dev:app",
     "flagAliases": [],
-    "flagChars": ["i", "n", "o", "t"],
-    "flags": ["device-id", "device-type", "flags-dir", "name", "target-org"],
+    "flagChars": ["b", "i", "n", "o", "t"],
+    "flags": ["browser", "device-id", "device-type", "flags-dir", "name", "target-org"],
     "plugin": "@salesforce/plugin-lightning-dev"
   },
   {

--- a/messages/lightning.dev.app.md
+++ b/messages/lightning.dev.app.md
@@ -31,6 +31,10 @@ Type of device to display the app preview.
 
 ID of the mobile device to display the preview if device type is set to `ios` or `android`. The default value is the ID of the first available mobile device.
 
+# flags.browser.summary
+
+Browser where the org opens in desktop preview.
+
 # error.username
 
 Org must have a valid user

--- a/src/commands/lightning/dev/app.ts
+++ b/src/commands/lightning/dev/app.ts
@@ -60,6 +60,11 @@ export default class LightningDevApp extends SfCommand<void> {
       summary: messages.getMessage('flags.device-id.summary'),
       char: 'i',
     }),
+    browser: Flags.option({
+      char: 'b',
+      summary: messages.getMessage('flags.browser.summary'),
+      options: ['chrome', 'edge', 'firefox'] as const, // These are ones supported by "open" package
+    })(),
   };
 
   public async run(): Promise<void> {
@@ -69,6 +74,7 @@ export default class LightningDevApp extends SfCommand<void> {
     const targetOrg = flags['target-org'];
     const appName = flags['name'];
     const deviceId = flags['device-id'];
+    const browser = flags['browser'];
 
     let sfdxProjectRootPath = '';
     try {
@@ -118,6 +124,7 @@ export default class LightningDevApp extends SfCommand<void> {
         ldpServerId,
         ldpServerUrl,
         appId,
+        browser,
         logger
       );
     } else {
@@ -143,6 +150,7 @@ export default class LightningDevApp extends SfCommand<void> {
     ldpServerId: string,
     ldpServerUrl: string,
     appId: string | undefined,
+    browser: string | undefined,
     logger: Logger
   ): Promise<void> {
     if (!appId) {
@@ -177,7 +185,8 @@ export default class LightningDevApp extends SfCommand<void> {
       ldpServerUrl,
       ldpServerId,
       appId,
-      targetOrg
+      targetOrg,
+      browser
     );
 
     // Start the LWC Dev Server

--- a/src/shared/previewUtils.ts
+++ b/src/shared/previewUtils.ts
@@ -146,6 +146,7 @@ export class PreviewUtils {
    * @param ldpServerId Record ID for the identity token
    * @param appId An optional app id for a targeted LEX app
    * @param targetOrg An optional org id
+   * @param browser An optional browser
    * @param auraMode An optional Aura Mode (defaults to DEVPREVIEW)
    * @returns Array of arguments to be used by Org:Open command for launching desktop browser
    */
@@ -154,6 +155,7 @@ export class PreviewUtils {
     ldpServerId: string,
     appId?: string,
     targetOrg?: string,
+    browser?: string,
     auraMode = DevPreviewAuraMode
   ): string[] {
     // appPath will resolve to one of the following:
@@ -171,6 +173,10 @@ export class PreviewUtils {
 
     if (targetOrg) {
       launchArguments.push('--target-org', targetOrg);
+    }
+
+    if (browser) {
+      launchArguments.push('--browser', browser);
     }
 
     return launchArguments;

--- a/test/commands/lightning/dev/app.test.ts
+++ b/test/commands/lightning/dev/app.test.ts
@@ -205,7 +205,7 @@ describe('lightning dev app', () => {
       ];
 
       if (browser) {
-        expectedParameters.push('--browser');
+        expectedParameters.push('--browser', browser);
       }
 
       expect(runCmdStub.calledOnce);

--- a/test/shared/previewUtils.test.ts
+++ b/test/shared/previewUtils.test.ts
@@ -110,6 +110,7 @@ describe('previewUtils', () => {
         testLdpServerId,
         'MyAppId',
         'MyTargetOrg',
+        'MyBrowser',
         'MyAuraMode'
       )
     ).to.deep.equal([
@@ -117,6 +118,8 @@ describe('previewUtils', () => {
       `lightning/app/MyAppId?0.aura.ldpServerUrl=MyLdpServerUrl&0.aura.ldpServerId=${testLdpServerId}&0.aura.mode=MyAuraMode`,
       '--target-org',
       'MyTargetOrg',
+      '--browser',
+      'MyBrowser',
     ]);
 
     expect(PreviewUtils.generateDesktopPreviewLaunchArguments('MyLdpServerUrl', testLdpServerId)).to.deep.equal([


### PR DESCRIPTION
### What does this PR do?

Adds a parameter `browser` which can be used to specify which browser the preview URL opens in when previewing on desktop. Corresponds to and is passed through to the `browser` parameter for the `org:open` command.

### What issues does this PR fix or reference?

Implements [#211](https://github.com/salesforcecli/plugin-lightning-dev/issues/211)
