### PR TITLE
fix: use absolute directories

### DIFF
--- a/src/lwc-dev-server/index.ts
+++ b/src/lwc-dev-server/index.ts
@@ -57,7 +57,9 @@ async function createLWCServerConfig(
   const { namespace } = projectJson;
 
   // e.g. lwc folders in force-app/main/default/lwc, package-dir/lwc
-  const namespacePaths = (await Promise.all(packageDirs.map((dir) => glob(`${dir.fullPath}/**/lwc`)))).flat();
+  const namespacePaths = (
+    await Promise.all(packageDirs.map((dir) => glob(`${dir.fullPath}/**/lwc`, { absolute: true })))
+  ).flat();
 
   const ports = serverPorts ??
     (await ConfigUtils.getLocalDevServerPorts()) ?? {


### PR DESCRIPTION
uses absolute paths instead of relative paths

fixes:
https://github.com/salesforcecli/plugin-lightning-dev/issues/261