### PR TITLE
feat: add open_browser env var for testing

### DIFF
--- a/src/commands/lightning/dev/site.ts
+++ b/src/commands/lightning/dev/site.ts
@@ -83,7 +83,7 @@ export default class LightningDevSite extends SfCommand<void> {
       const startupParams: LocalDevOptions = {
         sfCLI: true,
         authToken,
-        open: true,
+        open: process.env.OPEN_BROWSER === 'false' ? false : true,
         port,
         logLevel: 'error',
         mode: 'dev',


### PR DESCRIPTION
### What does this PR do?
Add env variable to skip opening the browser during CI testing.

### What issues does this PR fix or reference?
@W-15440520@
