### PR TITLE
feat: add api flags for testing sites

### DIFF
--- a/src/shared/experience/expSite.ts
+++ b/src/shared/experience/expSite.ts
@@ -238,7 +238,11 @@ export class ExperienceSite {
     try {
       // Limit API to published sites for now until we have a patch for the issues with unpublished sites
       // TODO switch api back to preview mode after issues are addressed
-      const apiUrl = `${instanceUrl}/services/data/v63.0/sites/${siteIdMinus3}/preview?published`;
+      let apiUrl = `${instanceUrl}/services/data/v63.0/sites/${siteIdMinus3}/preview?published`;
+      if (process.env.SITE_API_MODE === 'preview') {
+        apiUrl = `${instanceUrl}/services/data/v63.0/sites/${siteIdMinus3}/preview`;
+      }
+
       const response = await axios.get(apiUrl, {
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/src/shared/orgUtils.ts
+++ b/src/shared/orgUtils.ts
@@ -160,6 +160,11 @@ export class OrgUtils {
    * @param connection the connection to the org
    */
   public static ensureMatchingAPIVersion(connection: Connection): void {
+    // Testing purposes only - using this flag may cause local development to not function correctly
+    if (process.env.SKIP_API_VERSION_CHECK === 'true') {
+      return;
+    }
+
     const dirname = path.dirname(url.fileURLToPath(import.meta.url));
     const packageJsonFilePath = path.resolve(dirname, '../../package.json');
 


### PR DESCRIPTION
### What does this PR do?
- Add SITE_API_MODE flag to toggle how we are using the local dev api to generate site bundles (testing only)
- Add SKIP_API_VERSION_CHECK flag to ignore version mismatches (testing only)
### What issues does this PR fix or reference?
@W-17312145@