### PR TITLE
chore: address post-merge NUT review comments (W-23400737)

### DIFF
--- a/test/commands/lightning/dev/helpers/browserUtils.ts
+++ b/test/commands/lightning/dev/helpers/browserUtils.ts
@@ -28,7 +28,7 @@ import { Org } from '@salesforce/core';
  * @param session - TestSession with a default scratch org.
  * @returns The session ID string.
  */
-export async function getAccessToken(session: TestSession): Promise<string> {
+async function getAccessToken(session: TestSession): Promise<string> {
   const scratchOrg = session.orgs.get('default');
   const username = scratchOrg?.username ?? '';
   if (!username) {

--- a/test/commands/lightning/dev/helpers/sessionUtils.ts
+++ b/test/commands/lightning/dev/helpers/sessionUtils.ts
@@ -25,7 +25,7 @@ const PROJECT_PATH = path.resolve(PLUGIN_ROOT_PATH, 'test/projects/component-pre
 // Number of times TestSession will retry scratch org creation before failing. Scratch org
 // signup is intermittently flaky (RemoteOrgSignupFailed / C-9999); retrying avoids spurious
 // failures in the post-release pipeline. Overridable via TESTKIT_SETUP_RETRIES.
-const SETUP_RETRIES = Number.parseInt(process.env.TESTKIT_SETUP_RETRIES ?? '', 10) || 3;
+const SETUP_RETRIES = parseInt(process.env.TESTKIT_SETUP_RETRIES ?? '', 10) || 3;
 
 /**
  * Restores process.cwd() if it is currently a leaked sinon stub.


### PR DESCRIPTION
## What & why

Follow-up to #676 (W-23400737), addressing the two actionable review comments left after that PR merged:

1. **`getAccessToken` no longer exported** ([browserUtils.ts:31](https://github.com/salesforcecli/plugin-lightning-dev/blob/jhefferman/W-23400737-nut-review-followup/test/commands/lightning/dev/helpers/browserUtils.ts#L31)) — per @wjhsf, it's only referenced within `browserUtils.ts` (by `getPreview`), so the `export` was unnecessary.
2. **`Number.parseInt` → global `parseInt`** ([sessionUtils.ts:28](https://github.com/salesforcecli/plugin-lightning-dev/blob/jhefferman/W-23400737-nut-review-followup/test/commands/lightning/dev/helpers/sessionUtils.ts#L28)) — per @wjhsf, for consistency with the rest of the repo, which uses global `parseInt`/`parseFloat` throughout (`src/configMeta.ts`, `src/shared/previewUtils.ts`, and `devServerUtils.ts` in this same helper dir).

Both are test-helper-only, no behavior change. Lint + tsc + pre-commit hooks pass locally.

### Not addressed (already resolved on #676)
- @rax-it's "should we try a default version?" on `getMaxSupportedApiVersion` was answered inline and the PR was subsequently approved — fail-fast is intentional (an empty `apiVersionMetadata` means the plugin is misconfigured; the shipping `dependencyLoader.ts` reads the same map and would break too, and there's no canonical default version constant to fall back to).
- @wjhsf's design question ("what happens when the platform gets a new default API version but this package isn't updated?") is exactly the drift this fix is designed to absorb: the tests pin the preview to the plugin's own max supported version rather than the org's, so they stay green until a human adds the new version to `apiVersionMetadata` (+ its `@lwc/sfdx-local-dev-dist-<v>` dist). Adding real support for a newer API version remains a separate product task, by design.

@W-23400737@
