### PR TITLE
fix: add API version 68.0 support for live preview @W-24061445

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "dependencies": {
     "@inquirer/prompts": "^5.3.8",
     "@inquirer/select": "^2.4.7",
-    "@lwc/sfdx-local-dev-dist": "~13.3.19",
+    "@lwc/sfdx-local-dev-dist": "~15.0.2-alpha.0",
     "@lwc/sfdx-local-dev-dist-66.0": "npm:@lwc/sfdx-local-dev-dist@~13.2.24-alpha.0",
     "@lwc/sfdx-local-dev-dist-67.0": "npm:@lwc/sfdx-local-dev-dist@~13.3.19",
+    "@lwc/sfdx-local-dev-dist-68.0": "npm:@lwc/sfdx-local-dev-dist@~15.0.2-alpha.0",
     "@lwrjs/api": "0.21.8",
     "@oclif/core": "^4.5.6",
     "@salesforce/core": "^8.26.2",
@@ -246,6 +247,11 @@
     "67.0": {
       "dependencies": {
         "@lwc/sfdx-local-dev-dist": "~13.3.11"
+      }
+    },
+    "68.0": {
+      "dependencies": {
+        "@lwc/sfdx-local-dev-dist": "~15.0.2-alpha.0"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "dependencies": {
     "@inquirer/prompts": "^5.3.8",
     "@inquirer/select": "^2.4.7",
-    "@lwc/sfdx-local-dev-dist": "~15.0.2-alpha.0",
+    "@lwc/sfdx-local-dev-dist": "~15.0.7",
     "@lwc/sfdx-local-dev-dist-66.0": "npm:@lwc/sfdx-local-dev-dist@~13.2.24-alpha.0",
     "@lwc/sfdx-local-dev-dist-67.0": "npm:@lwc/sfdx-local-dev-dist@~13.3.19",
-    "@lwc/sfdx-local-dev-dist-68.0": "npm:@lwc/sfdx-local-dev-dist@~15.0.2-alpha.0",
+    "@lwc/sfdx-local-dev-dist-68.0": "npm:@lwc/sfdx-local-dev-dist@~15.0.7",
     "@lwrjs/api": "0.21.8",
     "@oclif/core": "^4.5.6",
     "@salesforce/core": "^8.26.2",
@@ -251,7 +251,7 @@
     },
     "68.0": {
       "dependencies": {
-        "@lwc/sfdx-local-dev-dist": "~15.0.2-alpha.0"
+        "@lwc/sfdx-local-dev-dist": "~15.0.7"
       }
     }
   },

--- a/src/types/aliased-deps.d.ts
+++ b/src/types/aliased-deps.d.ts
@@ -27,3 +27,7 @@ declare module '@lwc/sfdx-local-dev-dist-66.0' {
 declare module '@lwc/sfdx-local-dev-dist-67.0' {
   export * from '@lwc/sfdx-local-dev-dist';
 }
+
+declare module '@lwc/sfdx-local-dev-dist-68.0' {
+  export * from '@lwc/sfdx-local-dev-dist';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,6 +692,15 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.29.0", "@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.27.2":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.0.tgz#9fc6fd58c2a6a15243cd13983224968392070790"
@@ -737,6 +746,27 @@
     "@babel/template" "^7.28.6"
     "@babel/traverse" "^7.28.6"
     "@babel/types" "^7.28.6"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.0.tgz#5286ad785df7f79d656e88ce86e650d16ca5f322"
+  integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helpers" "^7.28.6"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
     "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
@@ -817,6 +847,17 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.29.0", "@babel/generator@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.8.tgz#4b0b887885422643339e09022148a4c4ebaa4979"
+  integrity sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==
+  dependencies:
+    "@babel/parser" "^7.29.8"
+    "@babel/types" "^7.29.8"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz#f31fd86b915fc4daf1f3ac6976c59be7084ed9c5"
@@ -876,6 +917,11 @@
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
 
 "@babel/helper-member-expression-to-functions@^7.27.1":
   version "7.27.1"
@@ -984,6 +1030,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.22.20", "@babel/helper-validator-identifier@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
@@ -993,6 +1044,11 @@
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
@@ -1039,6 +1095,13 @@
   dependencies:
     "@babel/types" "^7.28.5"
 
+"@babel/parser@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.0.tgz#669ef345add7d057e92b7ed15f0bac07611831b6"
+  integrity sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
 "@babel/parser@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.6.tgz#f01a8885b7fa1e56dd8a155130226cd698ef13fd"
@@ -1046,12 +1109,26 @@
   dependencies:
     "@babel/types" "^7.28.6"
 
+"@babel/parser@^7.29.0", "@babel/parser@^7.29.7", "@babel/parser@^7.29.8", "@babel/parser@~7.29.0":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
+  dependencies:
+    "@babel/types" "^7.29.8"
+
 "@babel/plugin-syntax-decorators@7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz#ee7dd9590aeebc05f9d4c8c0560007b05979a63d"
   integrity sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-syntax-decorators@7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz#8c3293a0fef033e4c786b35ce1e159fc1d676153"
+  integrity sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-jsx@^7.27.1":
   version "7.27.1"
@@ -1084,6 +1161,15 @@
     "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-remap-async-to-generator" "^7.27.1"
     "@babel/traverse" "^7.28.6"
+
+"@babel/plugin-transform-async-generator-functions@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz#63ed829820298f0bf143d5a4a68fb8c06ffd742f"
+  integrity sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/helper-remap-async-to-generator" "^7.27.1"
+    "@babel/traverse" "^7.29.0"
 
 "@babel/plugin-transform-async-to-generator@7.27.1":
   version "7.27.1"
@@ -1204,6 +1290,15 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/traverse@7.28.5", "@babel/traverse@^7.26.10", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.3", "@babel/traverse@^7.28.5", "@babel/traverse@~7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.5.tgz#450cab9135d21a7a2ca9d2d35aa05c20e68c360b"
@@ -1217,6 +1312,19 @@
     "@babel/types" "^7.28.5"
     debug "^4.3.1"
 
+"@babel/traverse@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+    debug "^4.3.1"
+
 "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.4", "@babel/traverse@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.6.tgz#871ddc79a80599a5030c53b1cc48cbe3a5583c2e"
@@ -1228,6 +1336,19 @@
     "@babel/parser" "^7.28.6"
     "@babel/template" "^7.28.6"
     "@babel/types" "^7.28.6"
+    debug "^4.3.1"
+
+"@babel/traverse@^7.29.0", "@babel/traverse@~7.29.0":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.8.tgz#4111014cdc71a0f95d9471907590baa0b8a6b28a"
+  integrity sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.8"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.8"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.8"
     debug "^4.3.1"
 
 "@babel/types@7.28.5", "@babel/types@^7.22.10", "@babel/types@^7.26.10", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.4", "@babel/types@^7.28.5", "@babel/types@^7.9.0", "@babel/types@~7.28.5":
@@ -1245,6 +1366,22 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.29.0", "@babel/types@^7.29.7", "@babel/types@^7.29.8", "@babel/types@~7.29.0":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@commitlint/cli@^17.1.2":
   version "17.8.1"
@@ -1584,6 +1721,15 @@
     debug "^4.3.1"
     minimatch "^3.1.2"
 
+"@eslint/config-array@^0.21.2":
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.21.2.tgz#f29e22057ad5316cf23836cee9a34c81fffcb7e6"
+  integrity sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==
+  dependencies:
+    "@eslint/object-schema" "^2.1.7"
+    debug "^4.3.1"
+    minimatch "^3.1.5"
+
 "@eslint/config-helpers@^0.4.1", "@eslint/config-helpers@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@eslint/config-helpers/-/config-helpers-0.4.2.tgz#1bd006ceeb7e2e55b2b773ab318d300e1a66aeda"
@@ -1635,6 +1781,21 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@eslint/eslintrc@^3.3.6":
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.7.tgz#76d3dedec4a30ea32df797bf8a0085c1311b7316"
+  integrity sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==
+  dependencies:
+    ajv "^6.14.0"
+    debug "^4.3.2"
+    espree "^10.0.1"
+    globals "^14.0.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.3.2"
+    minimatch "^3.1.5"
+    strip-json-comments "^3.1.1"
+
 "@eslint/js@8.57.1":
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
@@ -1649,6 +1810,11 @@
   version "9.39.2"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.39.2.tgz#2d4b8ec4c3ea13c1b3748e0c97ecd766bdd80599"
   integrity sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==
+
+"@eslint/js@9.39.5":
+  version "9.39.5"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.39.5.tgz#6f2fbcff75500d229d535e0a949ae13472c84787"
+  integrity sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==
 
 "@eslint/js@^9.17.0":
   version "9.29.0"
@@ -2202,6 +2368,16 @@
     "@babel/parser" "^7.9.0"
     "@babel/types" "^7.9.0"
 
+"@komaci/common-shared@^262.14.0":
+  version "262.22.0"
+  resolved "https://registry.yarnpkg.com/@komaci/common-shared/-/common-shared-262.22.0.tgz#005a2e855df3dae1a4c28edc3f11eb6db670124b"
+  integrity sha512-6dA9u6uDAqPv8bs2MKoU+mETlqHB+AwSauCoS+yN7TGDSWiU7eTIbZ22NRVMjxtrJnjoMqZ08bgVvDB2HzXhjw==
+  dependencies:
+    "@babel/core" "^7.9.0"
+    "@babel/generator" "^7.9.0"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
+
 "@komaci/esm-generator@260.31.0":
   version "260.31.0"
   resolved "https://registry.yarnpkg.com/@komaci/esm-generator/-/esm-generator-260.31.0.tgz#bbebbaa5b0ee41f387d9a09899125d149fe81d30"
@@ -2224,6 +2400,17 @@
     "@komaci/common-shared" "^260.32.0"
     "@komaci/static-analyzer" "^260.32.0"
 
+"@komaci/esm-generator@264.5.0":
+  version "264.5.0"
+  resolved "https://registry.yarnpkg.com/@komaci/esm-generator/-/esm-generator-264.5.0.tgz#2a4e1e048a40497227b3759e0955d4b9e7a1caa4"
+  integrity sha512-ZqNkTp5EbwyWL3zfHVae6gUlI5fG0sNB42xf7rwx5BJwPh4/eN7eH45mj2ylbK7P9d60uVbrMAqrE+d5C+w9og==
+  dependencies:
+    "@babel/core" "^7.9.0"
+    "@babel/generator" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    "@komaci/common-shared" "^262.14.0"
+    "@komaci/static-analyzer" "^262.14.0"
+
 "@komaci/static-analyzer@258.0.0":
   version "258.0.0"
   resolved "https://registry.yarnpkg.com/@komaci/static-analyzer/-/static-analyzer-258.0.0.tgz#133102c13a062b3ddd09e15ccb2e601e1b7feb8f"
@@ -2239,6 +2426,14 @@
   dependencies:
     "@babel/types" "^7.9.0"
     "@komaci/common-shared" "^260.32.0"
+
+"@komaci/static-analyzer@^262.14.0":
+  version "262.22.0"
+  resolved "https://registry.yarnpkg.com/@komaci/static-analyzer/-/static-analyzer-262.22.0.tgz#08e956580109a60371166941ffc212e7e10daaf4"
+  integrity sha512-lCGs/o6b1euG/Fi8REU6FQnX4SNYRrm7Rr+35nXZ7wGgJuvq8/pD/FrO8wLdsONvJDMYwr50Mc57KzUvwAeLrw==
+  dependencies:
+    "@babel/types" "^7.9.0"
+    "@komaci/common-shared" "^262.14.0"
 
 "@locker/babel-plugin-transform-unforgeables@0.22.0":
   version "0.22.0"
@@ -2356,6 +2551,16 @@
     "@lwc/shared" "8.28.2"
     line-column "~1.0.2"
 
+"@lwc/babel-plugin-component@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/babel-plugin-component/-/babel-plugin-component-9.1.1.tgz#65424161212daf1e9c1d0316c0bc06c0f644ca10"
+  integrity sha512-WRvO5ATDnqJLs8PldalJDyYyaQy2vgeGUKshFkqXja2knN0Id3oJzXykrz1b3hKgWZ4IfaC2arDfViBPjgzUlw==
+  dependencies:
+    "@babel/helper-module-imports" "7.28.6"
+    "@lwc/errors" "9.1.1"
+    "@lwc/shared" "9.1.1"
+    line-column "~1.0.2"
+
 "@lwc/compiler@8.25.1":
   version "8.25.1"
   resolved "https://registry.yarnpkg.com/@lwc/compiler/-/compiler-8.25.1.tgz#c7c50e29e6926fa73f5d1bec9c94ebc6cfb7099a"
@@ -2410,6 +2615,24 @@
     "@lwc/style-compiler" "8.28.2"
     "@lwc/template-compiler" "8.28.2"
 
+"@lwc/compiler@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/compiler/-/compiler-9.1.1.tgz#8373a2ebf7d4ca7a471b7f30d5393a1d477e8204"
+  integrity sha512-L2J132+nGP9JG4KK6pOcPlJ0lwbnA1YOAm1vI59V1RvXzCk1jVhpUUJZxKq16yzrTJDUXPuDzTpdgVCp381xwQ==
+  dependencies:
+    "@babel/core" "7.29.0"
+    "@babel/plugin-transform-async-generator-functions" "7.29.0"
+    "@babel/plugin-transform-async-to-generator" "7.28.6"
+    "@babel/plugin-transform-class-properties" "7.28.6"
+    "@babel/plugin-transform-object-rest-spread" "7.28.6"
+    "@locker/babel-plugin-transform-unforgeables" "0.22.0"
+    "@lwc/babel-plugin-component" "9.1.1"
+    "@lwc/errors" "9.1.1"
+    "@lwc/shared" "9.1.1"
+    "@lwc/ssr-compiler" "9.1.1"
+    "@lwc/style-compiler" "9.1.1"
+    "@lwc/template-compiler" "9.1.1"
+
 "@lwc/dev-server-plugin-lex@13.2.24-alpha.0+62759db":
   version "13.2.24-alpha.0"
   resolved "https://registry.yarnpkg.com/@lwc/dev-server-plugin-lex/-/dev-server-plugin-lex-13.2.24-alpha.0.tgz#f24b503e787073c7cd10dbb1ae713a3a5fb403df"
@@ -2421,6 +2644,13 @@
   version "13.3.19"
   resolved "https://registry.yarnpkg.com/@lwc/dev-server-plugin-lex/-/dev-server-plugin-lex-13.3.19.tgz#1ce9ad6dd853c4d722c7f5eba652f92495133334"
   integrity sha512-VFbLM368MaSAqqchDcnvgJSKYrT0viuVnh2mqSKauzLNV+/TCd4p31fgF4xRlJ8VocaKsWJD3FgXoYl26H/Hug==
+  dependencies:
+    magic-string "~0.30.21"
+
+"@lwc/dev-server-plugin-lex@15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/dev-server-plugin-lex/-/dev-server-plugin-lex-15.0.7.tgz#3211cc110faa11f9ab6acd669a11b20c5b312717"
+  integrity sha512-px547Ji4OWTpeFwY8sJIpE5C5h+YyMOJXa6sp4tI08RcYj0jck0BCQ+LVTmtce+gqPnhaie/TcAJFS0MiQ/Esg==
   dependencies:
     magic-string "~0.30.21"
 
@@ -2458,6 +2688,11 @@
   resolved "https://registry.yarnpkg.com/@lwc/errors/-/errors-8.28.2.tgz#50bae5dfd45f08be456d07180c600bd169f8c5e6"
   integrity sha512-zf4Z1JCILrpwi1BGrtm0iiDrtD0mlNxWpPZZrVY8rCycvKP8DQvw4sXQdATiwu9IJAMWsYckFj84xxod6jITxA==
 
+"@lwc/errors@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/errors/-/errors-9.1.1.tgz#d238ae22b6c4e2ec2cd7c5d2ab1d67e804c20483"
+  integrity sha512-mzxheWmXvmfbwWv5zzhL+uj0AsQXCfaq9HaAweY4ZYpGJ5iHGTVUT+dsyMJBcMzq/khYMwgNgAS0a9t4DqNljQ==
+
 "@lwc/eslint-plugin-lwc-platform@6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc-platform/-/eslint-plugin-lwc-platform-6.3.0.tgz#2abe8fcc15e187fbe1d453ed7d968382dadd8f48"
@@ -2471,6 +2706,15 @@
   integrity sha512-qTcRGGTdBAfuPlJTL2sTk65skQHqnthz8TRx/1IasFZb+aljSn+CamnaPyzq8s2xAzQsS+NZJQoWlrZjyzzCzw==
   dependencies:
     fast-xml-parser "^4.5.1"
+    globals "~15.14.0"
+    minimatch "~9.0.4"
+
+"@lwc/eslint-plugin-lwc@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-3.5.0.tgz#a0bb3b732c19ef0faa190dec0572b5aacdfe705a"
+  integrity sha512-Xq4i0ZWhBp1ZbGXqv8KEUqAOzo07BCD3yFD/EdOPafMjpXkeH5RpCFn09+sXVe1vdqtm47JwX+OUDXOMWfIsQg==
+  dependencies:
+    fast-xml-parser "^5.3.6"
     globals "~15.14.0"
     minimatch "~9.0.4"
 
@@ -2490,6 +2734,11 @@
   version "13.3.19"
   resolved "https://registry.yarnpkg.com/@lwc/lwc-dev-server-types/-/lwc-dev-server-types-13.3.19.tgz#873e1c9e46124f99a02d595a47e3e38c126f9f62"
   integrity sha512-a/jdnywF3c1qWLiEULow3WlWN1ybiEoV2eYPqAKl8az9gWssh2je2cx8ArEEh6xOManZM1ZZ7Wl+LpSzRHsAZQ==
+
+"@lwc/lwc-dev-server-types@15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/lwc-dev-server-types/-/lwc-dev-server-types-15.0.7.tgz#3598d8bb7204d8ad2601976606e84dd765a3732a"
+  integrity sha512-l8HI/9lNZIBk6kgzNIPBBeZUCJW69lv0Hvm+vdfT+M8RTHY4+hfxHxZG3JG+hdBFL7k8ZPFeVuc1El8H5nF1yw==
 
 "@lwc/lwc-dev-server@13.2.24-alpha.0+62759db":
   version "13.2.24-alpha.0"
@@ -2519,6 +2768,20 @@
     glob "^11.0.3"
     ws "^8.18.3"
 
+"@lwc/lwc-dev-server@15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/lwc-dev-server/-/lwc-dev-server-15.0.7.tgz#5ad069c465562f00b548e564073febb85600d18f"
+  integrity sha512-WiyvGN3AqJaqTxNwFcFNweK0dB4w01vSpwLkAKeHlG4xglbjNVhB57wMW4yccwvZ5ULowQjcOpUc5DRKlBpp0g==
+  dependencies:
+    "@lwc/lwc-dev-server-types" "15.0.7"
+    "@lwc/sfdc-lwc-compiler" "15.0.7"
+    chalk "~5.6.2"
+    chokidar "~3.6.0"
+    commander "~14.0.3"
+    fast-xml-parser "^5.3.7"
+    glob "^13.0.6"
+    ws "^8.20.0"
+
 "@lwc/metadata@13.2.24-alpha.0+62759db":
   version "13.2.24-alpha.0"
   resolved "https://registry.yarnpkg.com/@lwc/metadata/-/metadata-13.2.24-alpha.0.tgz#61d65b09ef5b50eabaa53f43c58fef441811329e"
@@ -2543,6 +2806,19 @@
     "@lwc/sfdc-compiler-utils" "13.3.19"
     postcss "~8.5.6"
     postcss-selector-parser "~7.1.0"
+    postcss-value-parser "~4.2.0"
+
+"@lwc/metadata@15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/metadata/-/metadata-15.0.7.tgz#09009eb2d03b82a6f19637871aabef94691ea8d3"
+  integrity sha512-unya6520x2J7VXc6XkJH99lYiyQTogQBk7WElaTzNoo2wiH1k5nW1d4LVYyUgp9OrKVoajRYEPvRTw3SVdMx/g==
+  dependencies:
+    "@babel/parser" "~7.29.0"
+    "@babel/traverse" "~7.29.0"
+    "@babel/types" "~7.29.0"
+    "@lwc/sfdc-compiler-utils" "15.0.7"
+    postcss "~8.5.6"
+    postcss-selector-parser "~7.1.1"
     postcss-value-parser "~4.2.0"
 
 "@lwc/module-resolver@8.28.2":
@@ -2571,6 +2847,11 @@
   version "13.3.19"
   resolved "https://registry.yarnpkg.com/@lwc/sfdc-compiler-utils/-/sfdc-compiler-utils-13.3.19.tgz#05cf8d087f0888e6ea0d0a3ef6a516794d60e09c"
   integrity sha512-uZrQeBnAU8s8hoJjN7FYVswebSYx2SLYWiOcJMfjaTZ8sBbLIh00ITN4IqX9XDlaBPhVCn1AHFK6cbrtlntOEg==
+
+"@lwc/sfdc-compiler-utils@15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/sfdc-compiler-utils/-/sfdc-compiler-utils-15.0.7.tgz#d64a2395f26a1ef596e15306be1654522c5e4718"
+  integrity sha512-VQ/dJjDiJkoGJX8xK4lYyz2GqxLfMDLaxi8N24FZ6HG5OBSWiC+6svtuvEr2txnn9XtoByu8cqUxCDJ+z27gxA==
 
 "@lwc/sfdc-lwc-compiler@13.2.24-alpha.0+62759db":
   version "13.2.24-alpha.0"
@@ -2645,6 +2926,45 @@
     postcss-selector-parser "~7.1.0"
     terser "~5.44.0"
 
+"@lwc/sfdc-lwc-compiler@15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/sfdc-lwc-compiler/-/sfdc-lwc-compiler-15.0.7.tgz#929391e349731f683f2e6f91daf9e2d81a0a78f7"
+  integrity sha512-Pm/rKL2cWSgXkRnvrO1AeaZEyWVPdnd0avEjAFWY8W5timHllP8oVRrCztWBPNDkeWzxsfIeVjPxYNGrNPYaEw==
+  dependencies:
+    "@babel/core" "7.29.0"
+    "@babel/parser" "7.29.0"
+    "@babel/plugin-syntax-decorators" "7.28.6"
+    "@babel/preset-typescript" "7.28.5"
+    "@babel/traverse" "7.29.0"
+    "@babel/types" "7.29.0"
+    "@komaci/esm-generator" "264.5.0"
+    "@lwc/dev-server-plugin-lex" "15.0.7"
+    "@lwc/eslint-plugin-lwc" "3.5.0"
+    "@lwc/eslint-plugin-lwc-platform" "6.3.0"
+    "@lwc/metadata" "15.0.7"
+    "@lwc/sfdc-compiler-utils" "15.0.7"
+    "@rollup/plugin-babel" "^6.1.0"
+    "@rollup/plugin-replace" "^6.0.3"
+    "@rollup/wasm-node" "4.52.5"
+    "@salesforce/eslint-config-lwc" "4.1.2"
+    "@salesforce/eslint-plugin-lightning" "2.0.0"
+    "@swc/wasm" "1.15.21"
+    astring "~1.9.0"
+    doctrine "~3.0.0"
+    eslint "~9.39.3"
+    eslint-plugin-import "~2.32.0"
+    glob "^13.0.6"
+    gray-matter "~4.0.3"
+    line-column "~1.0.2"
+    magic-string "~0.30.21"
+    markdown-it "~14.1.1"
+    meriyah "^7.1.0"
+    parse5-sax-parser "~8.0.0"
+    postcss "~8.5.6"
+    postcss-selector-parser "~7.1.1"
+    terser "~5.46.0"
+    typescript "5.9.3"
+
 "@lwc/sfdx-local-dev-dist-66.0@npm:@lwc/sfdx-local-dev-dist@~13.2.24-alpha.0":
   version "13.2.24-alpha.0"
   resolved "https://registry.yarnpkg.com/@lwc/sfdx-local-dev-dist/-/sfdx-local-dev-dist-13.2.24-alpha.0.tgz#dac216463bed7fd9e8ce005e3b0d1de2055b02e4"
@@ -2667,16 +2987,27 @@
     "@lwc/sfdc-lwc-compiler" "13.3.19"
     "@lwc/template-compiler" "8.27.0"
 
-"@lwc/sfdx-local-dev-dist@~13.3.19":
-  version "13.3.19"
-  resolved "https://registry.yarnpkg.com/@lwc/sfdx-local-dev-dist/-/sfdx-local-dev-dist-13.3.19.tgz#311242ea1166a590ec0ec8d96102f3e624204a6f"
-  integrity sha512-CwCG0SMfZmTSDyjqHHALpvjINUIFfHIs9MJUf/3XlPmQBDIt9in7iOPpxxmO5sSyZivuPA6VBPJKbwJ3gag5Mw==
+"@lwc/sfdx-local-dev-dist-68.0@npm:@lwc/sfdx-local-dev-dist@~15.0.2-alpha.0":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/sfdx-local-dev-dist/-/sfdx-local-dev-dist-15.0.7.tgz#40dbc702e6b2c922bc11ba7aebbc301cce0dc50c"
+  integrity sha512-ZM4l6mwd3A/fpcTvYfSVBOJUv52cg1zh3j3h2DLLsGvALQUSFmy9FOmDpEL9hDH/4Gv8SY1D+dlfuIymtrnQLg==
   dependencies:
-    "@lwc/compiler" "8.27.0"
-    "@lwc/errors" "8.27.0"
-    "@lwc/lwc-dev-server" "13.3.19"
-    "@lwc/sfdc-lwc-compiler" "13.3.19"
-    "@lwc/template-compiler" "8.27.0"
+    "@lwc/compiler" "9.1.1"
+    "@lwc/errors" "9.1.1"
+    "@lwc/lwc-dev-server" "15.0.7"
+    "@lwc/sfdc-lwc-compiler" "15.0.7"
+    "@lwc/template-compiler" "9.1.1"
+
+"@lwc/sfdx-local-dev-dist@~15.0.2-alpha.0":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@lwc/sfdx-local-dev-dist/-/sfdx-local-dev-dist-15.0.7.tgz#40dbc702e6b2c922bc11ba7aebbc301cce0dc50c"
+  integrity sha512-ZM4l6mwd3A/fpcTvYfSVBOJUv52cg1zh3j3h2DLLsGvALQUSFmy9FOmDpEL9hDH/4Gv8SY1D+dlfuIymtrnQLg==
+  dependencies:
+    "@lwc/compiler" "9.1.1"
+    "@lwc/errors" "9.1.1"
+    "@lwc/lwc-dev-server" "15.0.7"
+    "@lwc/sfdc-lwc-compiler" "15.0.7"
+    "@lwc/template-compiler" "9.1.1"
 
 "@lwc/shared@8.25.1":
   version "8.25.1"
@@ -2692,6 +3023,11 @@
   version "8.28.2"
   resolved "https://registry.yarnpkg.com/@lwc/shared/-/shared-8.28.2.tgz#7517dd415f30b2533454520073e4cab9f2a0fe97"
   integrity sha512-o3mic+/tl5blFVIhp/GES+mccm2NSBY2GNSZxcjDYfpWoBD8w8ePM3eLNQIoV7ts1gEq4VcCu2WhM9+Es21jxA==
+
+"@lwc/shared@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/shared/-/shared-9.1.1.tgz#f0e90844d04cfbbfc333a5df76d2c4e5ddd1fa99"
+  integrity sha512-0dQ5o9acJL+4eDRgjyozxxYeYi7SoycTO1Xc/UIjJLKwLzojxTkyITR3r4nH5CnVI/jnTNKs/WXXnjjJLa4OTg==
 
 "@lwc/signals@8.28.2":
   version "8.28.2"
@@ -2743,6 +3079,21 @@
     immer "^11.1.3"
     meriyah "^5.0.0"
 
+"@lwc/ssr-compiler@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/ssr-compiler/-/ssr-compiler-9.1.1.tgz#609c046931ec496c9b50ff2d53630fe865aa06df"
+  integrity sha512-u/Ib9OcoNSUvDPHOq0pt4B/jM/xJSBJ9fesuIrwEyBxpdPoEPiuCMPB1eVUt6hfZWAOS2hmvz9TIQz6K7eouhw==
+  dependencies:
+    "@babel/types" "7.29.0"
+    "@lwc/errors" "9.1.1"
+    "@lwc/shared" "9.1.1"
+    "@lwc/template-compiler" "9.1.1"
+    acorn "8.16.0"
+    astring "^1.9.0"
+    estree-toolkit "^1.7.13"
+    immer "^11.1.4"
+    meriyah "^7.1.0"
+
 "@lwc/ssr-runtime@8.28.2":
   version "8.28.2"
   resolved "https://registry.yarnpkg.com/@lwc/ssr-runtime/-/ssr-runtime-8.28.2.tgz#744e7836a6b7d83ed02d69d3e4b3e2999173a64f"
@@ -2775,6 +3126,16 @@
   dependencies:
     "@lwc/shared" "8.28.2"
     postcss "~8.5.6"
+    postcss-selector-parser "~7.1.1"
+    postcss-value-parser "~4.2.0"
+
+"@lwc/style-compiler@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/style-compiler/-/style-compiler-9.1.1.tgz#26478f098928000e428c1d29af2761b5afb66791"
+  integrity sha512-SQtxyO3yiyjdyiJOlWySUzvTtlYr5hqtjm83u5n1B/mLZVWFJz98QBH6ihrJPTNsamBtG061Wbt4AcM642rWRg==
+  dependencies:
+    "@lwc/shared" "9.1.1"
+    postcss "~8.5.8"
     postcss-selector-parser "~7.1.1"
     postcss-value-parser "~4.2.0"
 
@@ -2813,6 +3174,17 @@
     "@lwc/errors" "8.28.2"
     "@lwc/shared" "8.28.2"
     acorn "~8.15.0"
+    astring "~1.9.0"
+    he "~1.2.0"
+
+"@lwc/template-compiler@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@lwc/template-compiler/-/template-compiler-9.1.1.tgz#4d20428ae66c4d9e189cf914e54f2f8ceeb04dea"
+  integrity sha512-GzJqJNLWiJTa3vHr2IwcyTbjMNLkSofMqSvFa9s+krVX4Yqlut2cNcv3SumVKMkdJ5SOWg84GS5JJRxFir7fvQ==
+  dependencies:
+    "@lwc/errors" "9.1.1"
+    "@lwc/shared" "9.1.1"
+    acorn "~8.16.0"
     astring "~1.9.0"
     he "~1.2.0"
 
@@ -3213,6 +3585,11 @@
   integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
   dependencies:
     eslint-scope "5.1.1"
+
+"@nodable/entities@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-3.0.0.tgz#694703bc864d30eaed55c2e3def00dbd61493670"
+  integrity sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3866,6 +4243,18 @@
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@salesforce/eslint-config-lwc/-/eslint-config-lwc-4.1.1.tgz#9022d931ea20c683dc78ab5e95b17d0b8412c196"
   integrity sha512-twgNRNnFgD0rwIgtROQEJ0m9QQhEAVuQ4DgO8fmSPZiKlsJsLduULeLZtVzok6qSWLY3ZImetgMBPF7mv+I1kw==
+  dependencies:
+    "@babel/core" "~7.26.0"
+    "@babel/eslint-parser" "~7.25.9"
+    "@eslint/js" "^9.17.0"
+    eslint-restricted-globals "~0.2.0"
+    globals "~15.14.0"
+    semver "^7.6.2"
+
+"@salesforce/eslint-config-lwc@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/eslint-config-lwc/-/eslint-config-lwc-4.1.2.tgz#795606301842d15daf3553dc817eaaa172ae285d"
+  integrity sha512-GMoXOiqdSLYYuup8i6HWJYIScTGyOdgJCXXNzWb76Xa0RehqViigVAroTYB5OKvp4F5T7OLnGq06dARduphauQ==
   dependencies:
     "@babel/core" "~7.26.0"
     "@babel/eslint-parser" "~7.25.9"
@@ -4551,6 +4940,11 @@
   resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.14.0.tgz#456375a2b8d1a18a09e61e1dc333dfccd85b10a2"
   integrity sha512-eUUA3jEwFzoMh6mUksvaqX3wK+FxKFFFapBic+sQigxD5NytXM+PFARbv17BECKV/XcCCROHFV9+e73lYOsV3A==
 
+"@swc/wasm@1.15.21":
+  version "1.15.21"
+  resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.15.21.tgz#5c4c0a66fb3f5dae6a7846fd2b3a44a13520496f"
+  integrity sha512-AVomFdpE9LiB8Q0dNo1UqpqGut//Q7HJNyyCzyHsywHSUM/1pKfzywIjdha4WipgjyOPebYb93pTDBUn2iWvVA==
+
 "@swc/wasm@1.4.16":
   version "1.4.16"
   resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.4.16.tgz#30fe3514136ccfd6cc49373ff7080c7a41ba9a26"
@@ -5101,6 +5495,11 @@ acorn@8.15.0, acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1, acorn@^8.8.2, acorn@^8
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+acorn@8.16.0, acorn@~8.16.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -5127,6 +5526,16 @@ ajv@6.12.6, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.14.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -5208,6 +5617,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+anynum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
+  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
 
 append-transform@^2.0.0:
   version "2.0.0"
@@ -5896,6 +6310,11 @@ commander@~14.0.2:
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.2.tgz#b71fd37fe4069e4c3c7c13925252ada4eba14e8e"
   integrity sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==
+
+commander@~14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 comment-parser@1.4.1:
   version "1.4.1"
@@ -6978,6 +7397,46 @@ eslint@~9.39.1:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+eslint@~9.39.3:
+  version "9.39.5"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.39.5.tgz#2a4e3c8b0f753196efae943c8ffaa8730fc6a3fa"
+  integrity sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.8.0"
+    "@eslint-community/regexpp" "^4.12.1"
+    "@eslint/config-array" "^0.21.2"
+    "@eslint/config-helpers" "^0.4.2"
+    "@eslint/core" "^0.17.0"
+    "@eslint/eslintrc" "^3.3.6"
+    "@eslint/js" "9.39.5"
+    "@eslint/plugin-kit" "^0.4.1"
+    "@humanfs/node" "^0.16.6"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@humanwhocodes/retry" "^0.4.2"
+    "@types/estree" "^1.0.6"
+    ajv "^6.14.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.6"
+    debug "^4.3.2"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^8.4.0"
+    eslint-visitor-keys "^4.2.1"
+    espree "^10.4.0"
+    esquery "^1.5.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^8.0.0"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    ignore "^5.2.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.5"
+    natural-compare "^1.4.0"
+    optionator "^0.9.3"
+
 esmock@^2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esmock/-/esmock-2.7.3.tgz#25d8fd57b9608f9430185c501e7dab91fb1247bc"
@@ -7204,6 +7663,14 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
   integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
 
+fast-xml-builder@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz#ef05b353b45597483dfb09d450a062a2baec3a82"
+  integrity sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==
+  dependencies:
+    path-expression-matcher "^1.6.2"
+    xml-naming "^0.3.0"
+
 fast-xml-parser@5.3.6:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz#85a69117ca156b1b3c52e426495b6de266cb6a4b"
@@ -7224,6 +7691,18 @@ fast-xml-parser@^5.3.0:
   integrity sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==
   dependencies:
     strnum "^2.1.0"
+
+fast-xml-parser@^5.3.6, fast-xml-parser@^5.3.7:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz#0ee672fcce1710c38185b8290d77e98806ff0bfb"
+  integrity sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==
+  dependencies:
+    "@nodable/entities" "^3.0.0"
+    fast-xml-builder "^1.2.0"
+    is-unsafe "^2.0.0"
+    path-expression-matcher "^1.6.2"
+    strnum "^2.4.2"
+    xml-naming "^0.3.0"
 
 fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -8174,6 +8653,11 @@ immer@^11.1.0, immer@^11.1.3:
   resolved "https://registry.yarnpkg.com/immer/-/immer-11.1.3.tgz#78681e1deb6cec39753acf04eb16d7576c04f4d6"
   integrity sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==
 
+immer@^11.1.4:
+  version "11.1.18"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-11.1.18.tgz#87d9bced1e25157dc23bced66811de89460ec8f3"
+  integrity sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -8594,6 +9078,11 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+is-unsafe@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.2.tgz#bb1ead17f1aa688f6433258b561e98b1a45a1afc"
+  integrity sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==
+
 is-weakmap@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
@@ -8769,6 +9258,13 @@ js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.2.tgz#8e44fb14a2643c59726bb15787b5f1512cb3d3fb"
+  integrity sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==
   dependencies:
     argparse "^2.0.1"
 
@@ -9311,7 +9807,7 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-markdown-it@^14.1.0, markdown-it@~14.1.0:
+markdown-it@^14.1.0, markdown-it@~14.1.0, markdown-it@~14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.1.tgz#856f90b66fc39ae70affd25c1b18b581d7deee1f"
   integrity sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==
@@ -9517,6 +10013,11 @@ meriyah@^5.0.0:
   resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-5.0.0.tgz#9f5fd811ee6e7952dcb48cf6962f27a885f108b8"
   integrity sha512-tNlPDP4AzkH/7cROw7PKJ7mCLe/ZLpa2ja23uqB35vt63+8dgZi2NKLJMrkjxLcxArnLJVvd3Y/7pRl3OLR7yg==
 
+meriyah@^7.1.0:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-7.3.2.tgz#3e318f68602efd49aaf8199dc3650dd40242043f"
+  integrity sha512-uFPXbsoxaEd7PafMz3K/n/Z3kXz7iZBJtYU0VQB/kcV7i33+JghLTKweabLir480FUsyLz6gUIj4LW7kCQ35TA==
+
 methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -9663,6 +10164,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^5.0.1, minimatch@^5.1.6, minimatch@~5.1.1:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
@@ -9781,6 +10289,11 @@ nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -10280,6 +10793,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
+  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -10473,6 +10991,15 @@ postcss@^8.4.40, postcss@~8.5.6:
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
   dependencies:
     nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@~8.5.8:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  dependencies:
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -11682,6 +12209,13 @@ strnum@^2.1.2:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.1.2.tgz#a5e00ba66ab25f9cafa3726b567ce7a49170937a"
   integrity sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==
 
+strnum@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.2.tgz#af43ab51a06d04227023fc2e42ca229214ec10f0"
+  integrity sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==
+  dependencies:
+    anynum "^1.0.1"
+
 style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
@@ -11740,6 +12274,16 @@ terser@^5.17.4, terser@~5.44.0:
   version "5.44.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.44.0.tgz#ebefb8e5b8579d93111bfdfc39d2cf63879f4a82"
   integrity sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.15.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@~5.46.0:
+  version "5.46.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.46.2.tgz#b9529672d5b0024c7959571c83b82f65077b2a4f"
+  integrity sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.15.0"
@@ -12061,6 +12605,11 @@ typedoc@^0.26.5:
     minimatch "^9.0.5"
     shiki "^1.9.1"
     yaml "^2.4.5"
+
+typescript@5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 "typescript@^4.6.4 || ^5.2.2", typescript@^5.5.4:
   version "5.5.4"
@@ -12517,12 +13066,22 @@ ws@^8.15.0, ws@^8.18.0, ws@^8.18.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
+ws@^8.20.0:
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
+  integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
+
 wsl-utils@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/wsl-utils/-/wsl-utils-0.1.0.tgz#8783d4df671d4d50365be2ee4c71917a0557baab"
   integrity sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==
   dependencies:
     is-wsl "^3.1.0"
+
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz#46c1e18bfe2858479982dd2accf34d16e749eda2"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xml2js@^0.6.2:
   version "0.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,7 +2987,7 @@
     "@lwc/sfdc-lwc-compiler" "13.3.19"
     "@lwc/template-compiler" "8.27.0"
 
-"@lwc/sfdx-local-dev-dist-68.0@npm:@lwc/sfdx-local-dev-dist@~15.0.2-alpha.0":
+"@lwc/sfdx-local-dev-dist-68.0@npm:@lwc/sfdx-local-dev-dist@~15.0.7":
   version "15.0.7"
   resolved "https://registry.yarnpkg.com/@lwc/sfdx-local-dev-dist/-/sfdx-local-dev-dist-15.0.7.tgz#40dbc702e6b2c922bc11ba7aebbc301cce0dc50c"
   integrity sha512-ZM4l6mwd3A/fpcTvYfSVBOJUv52cg1zh3j3h2DLLsGvALQUSFmy9FOmDpEL9hDH/4Gv8SY1D+dlfuIymtrnQLg==
@@ -2998,7 +2998,7 @@
     "@lwc/sfdc-lwc-compiler" "15.0.7"
     "@lwc/template-compiler" "9.1.1"
 
-"@lwc/sfdx-local-dev-dist@~15.0.2-alpha.0":
+"@lwc/sfdx-local-dev-dist@~15.0.7":
   version "15.0.7"
   resolved "https://registry.yarnpkg.com/@lwc/sfdx-local-dev-dist/-/sfdx-local-dev-dist-15.0.7.tgz#40dbc702e6b2c922bc11ba7aebbc301cce0dc50c"
   integrity sha512-ZM4l6mwd3A/fpcTvYfSVBOJUv52cg1zh3j3h2DLLsGvALQUSFmy9FOmDpEL9hDH/4Gv8SY1D+dlfuIymtrnQLg==


### PR DESCRIPTION
## Summary
- Adds 68.0 to `apiVersionMetadata` and a matching `@lwc/sfdx-local-dev-dist-68.0` npm alias (pinned to the `15.0.2-alpha.0` prerelease) so `resolveApiVersion` stops rejecting orgs on API 68.0.
- Bumps the base `@lwc/sfdx-local-dev-dist` dep to match, per `.husky/check-versions.js`.

Fixes #682

@W-24061445@

## Test plan
- [x] `node .husky/check-versions.js`
- [x] `yarn build`
- [x] `yarn test`
